### PR TITLE
Feat/chaincmd dumpgenesis

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -249,6 +249,9 @@ func initGenesis(ctx *cli.Context) error {
 
 func dumpGenesis(ctx *cli.Context) error {
 	genesis := utils.MakeGenesis(ctx)
+	if genesis == nil {
+		genesis = core.DefaultGenesisBlock()
+	}
 	if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
 		utils.Fatalf("could not encode defaulty genesis")
 	}

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -57,6 +57,21 @@ participating.
 
 It expects the genesis file as argument.`,
 	}
+	dumpGenesisCommand = cli.Command{
+		Action:    utils.MigrateFlags(dumpGenesis),
+		Name:      "dumpgenesis",
+		Usage:     "Dumps genesis block JSON configuration to stdout",
+		ArgsUsage: "",
+		Flags: []cli.Flag{
+			utils.DataDirFlag,
+		},
+		Category: "BLOCKCHAIN COMMANDS",
+		Description: `
+The dumpgenesis command dumps the genesis block configuration in JSON format to stdout.
+
+This data can be used as a template or passed to the 'init' command. 
+`,
+	}
 	importCommand = cli.Command{
 		Action:    utils.MigrateFlags(importChain),
 		Name:      "import",
@@ -228,6 +243,14 @@ func initGenesis(ctx *cli.Context) error {
 		}
 		chaindb.Close()
 		log.Info("Successfully wrote genesis state", "database", name, "hash", hash)
+	}
+	return nil
+}
+
+func dumpGenesis(ctx *cli.Context) error {
+	genesis := utils.MakeGenesis(ctx)
+	if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
+		utils.Fatalf("could not encode defaulty genesis")
 	}
 	return nil
 }

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -253,7 +253,7 @@ func dumpGenesis(ctx *cli.Context) error {
 		genesis = core.DefaultGenesisBlock()
 	}
 	if err := json.NewEncoder(os.Stdout).Encode(genesis); err != nil {
-		utils.Fatalf("could not encode defaulty genesis")
+		utils.Fatalf("could not encode genesis")
 	}
 	return nil
 }

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -215,6 +215,7 @@ func init() {
 		copydbCommand,
 		removedbCommand,
 		dumpCommand,
+		dumpGenesisCommand,
 		inspectCommand,
 		// See accountcmd.go:
 		accountCommand,


### PR DESCRIPTION
I have a hard time believing this doesn't already exist... although I could not find it anywhere. @soc1c where/how do you make the configs like https://github.com/etclabscore/mordor/blob/master/mgeth.json ?

If it in fact this command (or an equivalent) doesn't already exist, then we should make this PR to ETH.

- Write genesis JSON config to stdout.

Use: 

```
$ ./build/bin/geth --classic dumpgenesis 2>/dev/null | jj config -p
{
  "chainId": 61,
  "homesteadBlock": 1150000,
  "eip7FBlock": null,
  "daoForkBlock": 1920000,
  "eip150Block": 2500000,
  "eip150Hash": "0xca12c63534f565899681965528d536c52cb05b7c48e269c2a6cb77ad864d878a",
  "eip155Block": 3000000,
  "eip158Block": 8772000,
  "eip160Block": 3000000,
  "byzantiumBlock": 8772000,
  "ecip1010PauseBlock": 3000000,
  "ecip1010Length": 2000000,
  "ecip1017EraRounds": 5000000,
  "disposalBlock": 5900000,
  "ethash": {},
  "trustedCheckpoint": null,
  "trustedCheckpointOracle": null
}
```