### PR TITLE
Release/etclabscore 1.9.3

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 const (
 	VersionMajor = 1          // Major version component of the current release
 	VersionMinor = 9          // Minor version component of the current release
-	VersionPatch = 3          // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionPatch = 4          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 	VersionName  = "MultiGeth"
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1          // Major version component of the current release
 	VersionMinor = 9          // Minor version component of the current release
 	VersionPatch = 3          // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMeta  = "stable" // Version metadata to append to the version string
 	VersionName  = "MultiGeth"
 )
 


### PR DESCRIPTION
Temporary release branch. Tag `v1.9.3-etclabscore` is on 1b398fb .

When release is finalized, a merge will bump hardcoded version parameters.