### PR TITLE
core: set mordor genesis block timestamp

### DIFF
--- a/core/genesis_mordor.go
+++ b/core/genesis_mordor.go
@@ -27,6 +27,7 @@ func DefaultMordorGenesisBlock() *Genesis {
 		ExtraData:  hexutil.MustDecode("0x70686f656e697820636869636b656e206162737572642062616e616e61"),
 		GasLimit:   hexutil.MustDecodeUint64("0x2fefd8"),
 		Difficulty: hexutil.MustDecodeBig("0x20000"),
+		Timestamp: hexutil.MustDecodeUint64("0x5d9676db"),
 		Alloc:      GenesisAlloc{},
 	}
 }


### PR DESCRIPTION
Fixes mordor chain genesis block mismatch.

Rel https://github.com/etclabscore/go-ethereum/issues/68