### PR TITLE
build: add test cmd flag -v for verbose logs

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -315,6 +315,7 @@ func goToolArch(arch string, cc string, subcmd string, args ...string) *exec.Cmd
 
 func doTest(cmdline []string) {
 	coverage := flag.Bool("coverage", false, "Whether to record code coverage")
+	verbose := flag.Bool("v", false, "Whether to log verbosely")
 	flag.CommandLine.Parse(cmdline)
 	env := build.Env()
 
@@ -330,6 +331,9 @@ func doTest(cmdline []string) {
 	gotest.Args = append(gotest.Args, "-p", "1", "-timeout", "5m", "--short")
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover")
+	}
+	if *verbose {
+		gotest.Args = append(gotest.Args, "-v")
 	}
 
 	gotest.Args = append(gotest.Args, packages...)


### PR DESCRIPTION
Adds flags akin to -coverage flag enabling the test runner
to use go test's -v flag, signaling verbose test log output.

---
This PR current based on `up/multi-geth` (#54) for reviewer's sake diffing, and assuming that changeset will be merged. Once and if it is merged, this PR's base should be modified to `master`. Otherwise, happy to merge as-is; whatever, happy to collab w/ reviewers here.