### PR TITLE
Makefile: add env var to enable args to test cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ios:
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 
 test: all
-	go run build/ci.go test
+	go run build/ci.go test $(testargs)
 
 lint: ## Run linters.
 	go run build/ci.go lint


### PR DESCRIPTION
Usage:
> make testargs=foo test

This allows make command to handle -coverage and other arbitrary
flags to the go command.

---

This PR current based on `up/multi-geth` (#54) for reviewer's sake diffing, and assuming that changeset will be merged. Once and if it is merged, this PR's base should be modified to `master`. Otherwise, happy to merge as-is; whatever, happy to collab w/ reviewers here.