### PR TITLE
appveyor.yml: new API key for AppVeyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,9 +44,10 @@ artifacts:
 
 deploy:
   provider: GitHub
+  repository: etclabscore/multi-geth
   artifact: /multi-geth.*-win64\.zip.*/
   auth_token:
-    secure: wzxjgHcWpMV6mDSyYkFrAV9brOyfeVvrgZhxTCFQDaA+AVIMGZazMdudcx4mLL7T
+    secure: 2ImMvNMj+kevxYhBcAzbqII4cGC/SIX1Kvp0yDwIOBveSr7n8FhX84o+XzOkY3cI
   draft: true
   on:
     appveyor_repo_tag: true


### PR DESCRIPTION
Because of problematic configuration of AppVeyor for organizations,
I'm using personal API key for build artifacts uploading to GitHub.

This resolves #72.