### PR TITLE
<many>: rename package params/types/common -> ctypes

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -40,7 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -65,7 +65,7 @@ type SimulatedBackend struct {
 
 	events *filters.EventSystem // Event system for filtering log events live
 
-	config common2.ChainConfigurator
+	config ctypes.ChainConfigurator
 }
 
 // NewSimulatedBackendWithDatabase creates a new binding backend based on the given database

--- a/cmd/evm/runner.go
+++ b/cmd/evm/runner.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -85,7 +85,7 @@ func runCmd(ctx *cli.Context) error {
 		tracer        vm.Tracer
 		debugLogger   *vm.StructLogger
 		statedb       *state.StateDB
-		chainConfig   common2.ChainConfigurator
+		chainConfig   ctypes.ChainConfigurator
 		sender        = common.BytesToAddress([]byte("sender"))
 		receiver      = common.BytesToAddress([]byte("receiver"))
 		genesisConfig *paramtypes.Genesis

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -59,7 +59,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/nat"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/gorilla/websocket"
 )
 
@@ -106,9 +106,9 @@ var (
 	gitDate   = "" // Git commit date YYYYMMDD of the release (set via linker flags)
 )
 
-func faucetDirFromConfig(chainConfig common2.ChainConfigurator) string {
+func faucetDirFromConfig(chainConfig ctypes.ChainConfigurator) string {
 	datadir := filepath.Join(os.Getenv("HOME"), ".faucet")
-	for conf, suff := range map[common2.ChainConfigurator]string{
+	for conf, suff := range map[ctypes.ChainConfigurator]string{
 		params.MainnetChainConfig:     "",
 		params.ClassicChainConfig:     "classic",
 		params.SocialChainConfig:      "social",
@@ -317,7 +317,7 @@ type request struct {
 
 // faucet represents a crypto faucet backed by an Ethereum light client.
 type faucet struct {
-	config common2.ChainConfigurator // Chain configurations for signing
+	config ctypes.ChainConfigurator // Chain configurations for signing
 	stack  *node.Node                // Ethereum protocol stack
 	client *ethclient.Client         // Client connection to the Ethereum chain
 	index  []byte                    // Index page to serve up on the web

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -43,7 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -107,7 +107,7 @@ type RetestWeb3API interface {
 type RetestethAPI struct {
 	ethDb         ethdb.Database
 	db            state.Database
-	chainConfig   common2.ChainConfigurator
+	chainConfig   ctypes.ChainConfigurator
 	author        common.Address
 	extraData     []byte
 	genesisHash   common.Hash
@@ -223,7 +223,7 @@ func (e *NoRewardEngine) Prepare(chain consensus.ChainReader, header *types.Head
 	return e.inner.Prepare(chain, header)
 }
 
-func (e *NoRewardEngine) accumulateRewards(config common2.ChainConfigurator, state *state.StateDB, header *types.Header, uncles []*types.Header) {
+func (e *NoRewardEngine) accumulateRewards(config ctypes.ChainConfigurator, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 	// Simply touch miner and uncle coinbase accounts
 	reward := big.NewInt(0)
 	for _, uncle := range uncles {

--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params/convert"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -66,13 +66,13 @@ func (w *wizard) makeGenesis() {
 	switch {
 	case choice == "1":
 		// In case of ethash, we're pretty much done
-		genesis.Config.MustSetConsensusEngineType(common2.ConsensusEngineT_Ethash)
+		genesis.Config.MustSetConsensusEngineType(ctypes.ConsensusEngineT_Ethash)
 		genesis.ExtraData = make([]byte, 32)
 
 	case choice == "" || choice == "2":
 		// In the case of clique, configure the consensus parameters
 		genesis.Difficulty = big.NewInt(1)
-		genesis.Config.MustSetConsensusEngineType(common2.ConsensusEngineT_Clique)
+		genesis.Config.MustSetConsensusEngineType(ctypes.ConsensusEngineT_Clique)
 		genesis.Config.SetCliquePeriod(15)
 		genesis.Config.SetCliqueEpoch(30000)
 		fmt.Println()

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -31,7 +31,7 @@ import (
 // blockchain during header and/or uncle verification.
 type ChainReader interface {
 	// Config retrieves the blockchain's chain configuration.
-	Config() common2.ChainConfigurator
+	Config() ctypes.ChainConfigurator
 
 	// CurrentHeader retrieves the current header from the local chain.
 	CurrentHeader() *types.Header

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
@@ -304,7 +304,7 @@ func parent_diff_over_dbd(p *types.Header) *big.Int {
 // CalcDifficulty is the difficulty adjustment algorithm. It returns
 // the difficulty that a new block should have when created at time
 // given the parent block's time and difficulty.
-func CalcDifficulty(config common2.ChainConfigurator, time uint64, parent *types.Header) *big.Int {
+func CalcDifficulty(config ctypes.ChainConfigurator, time uint64, parent *types.Header) *big.Int {
 	next := new(big.Int).Add(parent.Number, big1)
 	out := new(big.Int)
 
@@ -573,13 +573,13 @@ var (
 // AccumulateRewards credits the coinbase of the given block with the mining
 // reward. The total reward consists of the static block reward and rewards for
 // included uncles. The coinbase of each uncle block is also rewarded.
-func accumulateRewards(config common2.ChainConfigurator, state *state.StateDB, header *types.Header, uncles []*types.Header) {
+func accumulateRewards(config ctypes.ChainConfigurator, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 	if config.IsForked(config.GetEthashECIP1017Transition, header.Number) {
 		ecip1017BlockReward(config, state, header, uncles)
 		return
 	}
 
-	blockReward := common2.EthashBlockReward(config, header.Number)
+	blockReward := ctypes.EthashBlockReward(config, header.Number)
 
 	// Accumulate the rewards for the miner and any included uncles
 	reward := new(big.Int).Set(blockReward)

--- a/consensus/ethash/consensus_classic.go
+++ b/consensus/ethash/consensus_classic.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
-func ecip1017BlockReward(config common2.ChainConfigurator, state *state.StateDB, header *types.Header, uncles []*types.Header) {
+func ecip1017BlockReward(config ctypes.ChainConfigurator, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 	blockReward := vars.FrontierBlockReward
 
 	// Ensure value 'era' is configured.
@@ -42,7 +42,7 @@ func ecip1017BlockReward(config common2.ChainConfigurator, state *state.StateDB,
 	}
 }
 
-func ecip1010Explosion(config common2.ChainConfigurator, next *big.Int, exPeriodRef *big.Int) {
+func ecip1010Explosion(config ctypes.ChainConfigurator, next *big.Int, exPeriodRef *big.Int) {
 	// https://github.com/ethereumproject/ECIPs/blob/master/ECIPs/ECIP-1010.md
 
 	if next.Uint64() < *config.GetEthashECIP1010ContinueTransition() {

--- a/consensus/misc/dao.go
+++ b/consensus/misc/dao.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params/convert"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -46,7 +46,7 @@ var (
 //      with the fork specific extra-data set
 //   b) if the node is pro-fork, require blocks in the specific range to have the
 //      unique extra-data set.
-func VerifyDAOHeaderExtraData(config common.ChainConfigurator, header *types.Header) error {
+func VerifyDAOHeaderExtraData(config ctypes.ChainConfigurator, header *types.Header) error {
 	// Short circuit validation if the node doesn't care about the DAO fork
 	daoForkBlock := config.GetEthashEIP779Transition()
 	// Second clause catches test configs with nil fork blocks (maybe set dynamically or

--- a/consensus/misc/forks.go
+++ b/consensus/misc/forks.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 // VerifyForkHashes verifies that blocks conforming to network hard-forks do have
 // the correct hashes, to avoid clients going off on different chains. This is an
 // optional feature.
-func VerifyForkHashes(config common2.ChainConfigurator, header *types.Header, uncle bool) error {
+func VerifyForkHashes(config ctypes.ChainConfigurator, header *types.Header, uncle bool) error {
 	// We don't care about uncles
 	if uncle {
 		return nil

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -31,13 +31,13 @@ import (
 //
 // BlockValidator implements Validator.
 type BlockValidator struct {
-	config common2.ChainConfigurator // Chain configuration options
+	config ctypes.ChainConfigurator // Chain configuration options
 	bc     *BlockChain               // Canonical block chain
 	engine consensus.Engine          // Consensus engine used for validating
 }
 
 // NewBlockValidator returns a new block validator which is safe for re-use
-func NewBlockValidator(config common2.ChainConfigurator, blockchain *BlockChain, engine consensus.Engine) *BlockValidator {
+func NewBlockValidator(config ctypes.ChainConfigurator, blockchain *BlockChain, engine consensus.Engine) *BlockValidator {
 	validator := &BlockValidator{
 		config: config,
 		engine: engine,

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -39,7 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
 	lru "github.com/hashicorp/golang-lru"
@@ -131,7 +131,7 @@ type CacheConfig struct {
 // included in the canonical one where as GetBlockByNumber always represents the
 // canonical chain.
 type BlockChain struct {
-	chainConfig common2.ChainConfigurator // Chain & network configuration
+	chainConfig ctypes.ChainConfigurator // Chain & network configuration
 	cacheConfig *CacheConfig            // Cache configuration for pruning
 
 	db     ethdb.Database // Low level persistent database to store final content in
@@ -181,7 +181,7 @@ type BlockChain struct {
 // NewBlockChain returns a fully initialised block chain using information
 // available in the database. It initialises the default Ethereum Validator and
 // Processor.
-func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig common2.ChainConfigurator, engine consensus.Engine, vmConfig vm.Config, shouldPreserve func(block *types.Block) bool) (*BlockChain, error) {
+func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig ctypes.ChainConfigurator, engine consensus.Engine, vmConfig vm.Config, shouldPreserve func(block *types.Block) bool) (*BlockChain, error) {
 	if cacheConfig == nil {
 		cacheConfig = &CacheConfig{
 			TrieCleanLimit: 256,
@@ -2189,7 +2189,7 @@ func (bc *BlockChain) GetTransactionLookup(hash common.Hash) *rawdb.LegacyTxLook
 }
 
 // Config retrieves the chain's fork configuration.
-func (bc *BlockChain) Config() common2.ChainConfigurator { return bc.chainConfig }
+func (bc *BlockChain) Config() ctypes.ChainConfigurator { return bc.chainConfig }
 
 // Engine retrieves the blockchain's consensus engine.
 func (bc *BlockChain) Engine() consensus.Engine { return bc.engine }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/convert"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -47,7 +47,7 @@ type BlockGen struct {
 	receipts []*types.Receipt
 	uncles   []*types.Header
 
-	config common2.ChainConfigurator
+	config ctypes.ChainConfigurator
 	engine consensus.Engine
 }
 
@@ -188,7 +188,7 @@ func (b *BlockGen) OffsetTime(seconds int64) {
 // Blocks created by GenerateChain do not contain valid proof of work
 // values. Inserting them into BlockChain requires use of FakePow or
 // a similar non-validating proof of work implementation.
-func GenerateChain(config common2.ChainConfigurator, parent *types.Block, engine consensus.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
+func GenerateChain(config ctypes.ChainConfigurator, parent *types.Block, engine consensus.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
 	if config == nil {
 		config = params.TestChainConfig
 	}
@@ -286,12 +286,12 @@ func makeBlockChain(parent *types.Block, n int, engine consensus.Engine, db ethd
 }
 
 type fakeChainReader struct {
-	config  common2.ChainConfigurator
+	config  ctypes.ChainConfigurator
 	genesis *types.Block
 }
 
 // Config returns the chain configuration.
-func (cr *fakeChainReader) Config() common2.ChainConfigurator {
+func (cr *fakeChainReader) Config() ctypes.ChainConfigurator {
 	return cr.config
 }
 

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 var (
@@ -62,7 +62,7 @@ func NewID(chain *core.BlockChain) ID {
 // newID is the internal version of NewID, which takes extracted values as its
 // arguments instead of a chain. The reason is to allow testing the IDs without
 // having to simulate an entire blockchain.
-func newID(config common2.ChainConfigurator, genesis common.Hash, head uint64) ID {
+func newID(config ctypes.ChainConfigurator, genesis common.Hash, head uint64) ID {
 	// Calculate the starting checksum from the genesis hash
 	hash := crc32.ChecksumIEEE(genesis[:])
 
@@ -93,7 +93,7 @@ func NewFilter(chain *core.BlockChain) Filter {
 }
 
 // NewStaticFilter creates a filter at block zero.
-func NewStaticFilter(config common2.ChainConfigurator, genesis common.Hash) Filter {
+func NewStaticFilter(config ctypes.ChainConfigurator, genesis common.Hash) Filter {
 	head := func() uint64 { return 0 }
 	return newFilter(config, genesis, head)
 }
@@ -101,7 +101,7 @@ func NewStaticFilter(config common2.ChainConfigurator, genesis common.Hash) Filt
 // newFilter is the internal version of NewFilter, taking closures as its arguments
 // instead of a chain. The reason is to allow testing it without having to simulate
 // an entire blockchain.
-func newFilter(config common2.ChainConfigurator, genesis common.Hash, headfn func() uint64) Filter {
+func newFilter(config ctypes.ChainConfigurator, genesis common.Hash, headfn func() uint64) Filter {
 	// Calculate the all the valid fork hash and fork next combos
 	var (
 		forks = gatherForks(config)
@@ -206,6 +206,6 @@ func checksumToBytes(hash uint32) [4]byte {
 }
 
 // gatherForks gathers all the known forks and creates a sorted list out of them.
-func gatherForks(config common2.ChainConfigurator) []uint64 {
-	return common2.Forks(config)
+func gatherForks(config ctypes.ChainConfigurator) []uint64 {
+	return ctypes.Forks(config)
 }

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -37,7 +37,7 @@ func TestCreation(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		config  common2.ChainConfigurator
+		config  ctypes.ChainConfigurator
 		genesis common.Hash
 		cases   []testcase
 	}{

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/convert"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -46,12 +46,12 @@ import (
 // error is a *params.ConfigCompatError and the new, unwritten config is returned.
 //
 // The returned chain configuration is never nil.
-func SetupGenesisBlock(db ethdb.Database, genesis *paramtypes.Genesis) (common2.ChainConfigurator, common.Hash, error) {
+func SetupGenesisBlock(db ethdb.Database, genesis *paramtypes.Genesis) (ctypes.ChainConfigurator, common.Hash, error) {
 	return SetupGenesisBlockWithOverride(db, genesis)
 }
 
-func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *paramtypes.Genesis) (common2.ChainConfigurator, common.Hash, error) {
-	if genesis != nil && common2.IsEmpty(genesis.Config) {
+func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *paramtypes.Genesis) (ctypes.ChainConfigurator, common.Hash, error) {
+	if genesis != nil && ctypes.IsEmpty(genesis.Config) {
 		return params.AllEthashProtocolChanges, common.Hash{}, paramtypes.ErrGenesisNoConfig
 	}
 	// Just commit the new block if there is no stored genesis block.
@@ -128,7 +128,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *paramtypes.Genesi
 	if height == nil {
 		return newcfg, stored, fmt.Errorf("missing block number for head header hash")
 	}
-	compatErr := common2.Compatible(height, storedcfg, newcfg)
+	compatErr := ctypes.Compatible(height, storedcfg, newcfg)
 	if compatErr != nil && *height != 0 && compatErr.RewindTo != 0 {
 		return newcfg, stored, compatErr
 	}
@@ -136,7 +136,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *paramtypes.Genesi
 	return newcfg, stored, nil
 }
 
-func configOrDefault(g *paramtypes.Genesis, ghash common.Hash) common2.ChainConfigurator {
+func configOrDefault(g *paramtypes.Genesis, ghash common.Hash) ctypes.ChainConfigurator {
 	switch {
 	case g != nil:
 		return g.Config

--- a/core/genesis_alloc_test.go
+++ b/core/genesis_alloc_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/go-test/deep"
 )
@@ -59,14 +59,14 @@ func TestSetupGenesis(t *testing.T) {
 	oldcustomg.Config = &goethereum.ChainConfig{HomesteadBlock: big.NewInt(2)}
 	tests := []struct {
 		name       string
-		fn         func(ethdb.Database) (common2.ChainConfigurator, common.Hash, error)
+		fn         func(ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error)
 		wantConfig *goethereum.ChainConfig
 		wantHash   common.Hash
 		wantErr    error
 	}{
 		{
 			name: "genesis without MultiGethChainConfig",
-			fn: func(db ethdb.Database) (common2.ChainConfigurator, common.Hash, error) {
+			fn: func(db ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error) {
 				return SetupGenesisBlock(db, new(paramtypes.Genesis))
 			},
 			wantErr:    paramtypes.ErrGenesisNoConfig,
@@ -74,7 +74,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "no block in DB, genesis == nil",
-			fn: func(db ethdb.Database) (common2.ChainConfigurator, common.Hash, error) {
+			fn: func(db ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error) {
 				return SetupGenesisBlock(db, nil)
 			},
 			wantHash:   params.MainnetGenesisHash,
@@ -82,7 +82,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "mainnet block in DB, genesis == nil",
-			fn: func(db ethdb.Database) (common2.ChainConfigurator, common.Hash, error) {
+			fn: func(db ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error) {
 				MustCommitGenesis(db, params.DefaultGenesisBlock())
 				return SetupGenesisBlock(db, nil)
 			},
@@ -91,7 +91,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "custom block in DB, genesis == nil",
-			fn: func(db ethdb.Database) (common2.ChainConfigurator, common.Hash, error) {
+			fn: func(db ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error) {
 				MustCommitGenesis(db, &customg)
 				return SetupGenesisBlock(db, nil)
 			},
@@ -100,7 +100,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "custom block in DB, genesis == testnet",
-			fn: func(db ethdb.Database) (common2.ChainConfigurator, common.Hash, error) {
+			fn: func(db ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error) {
 				MustCommitGenesis(db, &customg)
 				return SetupGenesisBlock(db, params.DefaultTestnetGenesisBlock())
 			},
@@ -110,7 +110,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "compatible config in DB",
-			fn: func(db ethdb.Database) (common2.ChainConfigurator, common.Hash, error) {
+			fn: func(db ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error) {
 				MustCommitGenesis(db, &oldcustomg)
 				return SetupGenesisBlock(db, &customg)
 			},
@@ -119,7 +119,7 @@ func TestSetupGenesis(t *testing.T) {
 		},
 		{
 			name: "incompatible config in DB",
-			fn: func(db ethdb.Database) (common2.ChainConfigurator, common.Hash, error) {
+			fn: func(db ethdb.Database) (ctypes.ChainConfigurator, common.Hash, error) {
 				// Commit the 'old' genesis block with Homestead transition at #2.
 				// Advance to block #4, past the homestead transition block of customg.
 				genesis := MustCommitGenesis(db, &oldcustomg)
@@ -135,7 +135,7 @@ func TestSetupGenesis(t *testing.T) {
 			},
 			wantHash:   customghash,
 			wantConfig: customg.Config.(*goethereum.ChainConfig),
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "incompatible fork value: GetEIP7Transition",
 				StoredConfig: func() *uint64 { b := big.NewInt(2).Uint64(); return &b }(),
 				NewConfig:    func() *uint64 { b := big.NewInt(3).Uint64(); return &b }(),

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -24,7 +24,7 @@ import (
 		"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/convert"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 func TestSetupGenesisBlock(t *testing.T) {
@@ -39,7 +39,7 @@ func TestSetupGenesisBlock(t *testing.T) {
 	if wantHash := GenesisToBlock(defGenBl, nil).Hash(); wantHash != hash  {
 		t.Errorf("mismatch block hash, want: %x, got: %x", wantHash, hash)
 	}
-	if diffs := convert.Equal(reflect.TypeOf((*common.ChainConfigurator)(nil)), defGenBl.Config, config); len(diffs) != 0 {
+	if diffs := convert.Equal(reflect.TypeOf((*ctypes.ChainConfigurator)(nil)), defGenBl.Config, config); len(diffs) != 0 {
 		for _, diff := range diffs {
 			t.Error("mismatch", "diff=", diff, "in", defGenBl.Config, "out", config)
 		}
@@ -54,7 +54,7 @@ func TestSetupGenesisBlock(t *testing.T) {
 	if wantHash := GenesisToBlock(clGenBl, nil).Hash(); wantHash != clHash  {
 		t.Errorf("mismatch block hash, want: %x, got: %x", wantHash, clHash)
 	}
-	if diffs := convert.Equal(reflect.TypeOf((*common.ChainConfigurator)(nil)), clGenBl.Config, clConfig); len(diffs) != 0 {
+	if diffs := convert.Equal(reflect.TypeOf((*ctypes.ChainConfigurator)(nil)), clGenBl.Config, clConfig); len(diffs) != 0 {
 		for _, diff := range diffs {
 			t.Error("mismatch", "diff=", diff, "in", clGenBl.Config, "out", clConfig)
 		}

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	lru "github.com/hashicorp/golang-lru"
 )
 
@@ -48,7 +48,7 @@ const (
 // It is not thread safe either, the encapsulating chain structures should do
 // the necessary mutex locking/unlocking.
 type HeaderChain struct {
-	config common2.ChainConfigurator
+	config ctypes.ChainConfigurator
 
 	chainDb       ethdb.Database
 	genesisHeader *types.Header
@@ -70,7 +70,7 @@ type HeaderChain struct {
 //  getValidator should return the parent's validator
 //  procInterrupt points to the parent's interrupt semaphore
 //  wg points to the parent's shutdown wait group
-func NewHeaderChain(chainDb ethdb.Database, config common2.ChainConfigurator, engine consensus.Engine, procInterrupt func() bool) (*HeaderChain, error) {
+func NewHeaderChain(chainDb ethdb.Database, config ctypes.ChainConfigurator, engine consensus.Engine, procInterrupt func() bool) (*HeaderChain, error) {
 	headerCache, _ := lru.New(headerCacheLimit)
 	tdCache, _ := lru.New(tdCacheLimit)
 	numberCache, _ := lru.New(numberCacheLimit)
@@ -533,7 +533,7 @@ func (hc *HeaderChain) SetGenesis(head *types.Header) {
 }
 
 // Config retrieves the header chain's chain configuration.
-func (hc *HeaderChain) Config() common2.ChainConfigurator { return hc.config }
+func (hc *HeaderChain) Config() ctypes.ChainConfigurator { return hc.config }
 
 // Engine retrieves the header chain's consensus engine.
 func (hc *HeaderChain) Engine() consensus.Engine { return hc.engine }

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -418,7 +418,7 @@ func ReadRawReceipts(db ethdb.Reader, hash common.Hash, number uint64) types.Rec
 // The current implementation populates these metadata fields by reading the receipts'
 // corresponding block body, so if the block body is not found it will return nil even
 // if the receipt itself is stored.
-func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config common2.ChainConfigurator) types.Receipts {
+func ReadReceipts(db ethdb.Reader, hash common.Hash, number uint64, config ctypes.ChainConfigurator) types.Receipts {
 	// We're deriving many fields from the block body, retrieve beside the receipt
 	receipts := ReadRawReceipts(db, hash, number)
 	if receipts == nil {

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -95,7 +95,7 @@ func ReadTransaction(db ethdb.Reader, hash common.Hash) (*types.Transaction, com
 
 // ReadReceipt retrieves a specific transaction receipt from the database, along with
 // its added positional metadata.
-func ReadReceipt(db ethdb.Reader, hash common.Hash, config common2.ChainConfigurator) (*types.Receipt, common.Hash, uint64, uint64) {
+func ReadReceipt(db ethdb.Reader, hash common.Hash, config ctypes.ChainConfigurator) (*types.Receipt, common.Hash, uint64, uint64) {
 	// Retrieve the context of the receipt based on the transaction hash
 	blockNumber := ReadTxLookupEntry(db, hash)
 	if blockNumber == nil {

--- a/core/rawdb/accessors_metadata.go
+++ b/core/rawdb/accessors_metadata.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params/convert"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -54,7 +54,7 @@ func WriteDatabaseVersion(db ethdb.KeyValueWriter, version uint64) {
 }
 
 // ReadChainConfig retrieves the consensus settings based on the given genesis hash.
-func ReadChainConfig(db ethdb.KeyValueReader, hash common.Hash) common2.ChainConfigurator {
+func ReadChainConfig(db ethdb.KeyValueReader, hash common.Hash) ctypes.ChainConfigurator {
 	data, _ := db.Get(configKey(hash))
 	if len(data) == 0 {
 		return nil
@@ -68,7 +68,7 @@ func ReadChainConfig(db ethdb.KeyValueReader, hash common.Hash) common2.ChainCon
 }
 
 // WriteChainConfig writes the chain config settings to the database.
-func WriteChainConfig(db ethdb.KeyValueWriter, hash common.Hash, cfg common2.ChainConfigurator) {
+func WriteChainConfig(db ethdb.KeyValueWriter, hash common.Hash, cfg ctypes.ChainConfigurator) {
 	if cfg == nil {
 		return
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -24,20 +24,20 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 // statePrefetcher is a basic Prefetcher, which blindly executes a block on top
 // of an arbitrary state with the goal of prefetching potentially useful state
 // data from disk before the main block processor start executing.
 type statePrefetcher struct {
-	config common2.ChainConfigurator // Chain configuration options
+	config ctypes.ChainConfigurator // Chain configuration options
 	bc     *BlockChain             // Canonical block chain
 	engine consensus.Engine        // Consensus engine used for block rewards
 }
 
 // newStatePrefetcher initialises a new statePrefetcher.
-func newStatePrefetcher(config common2.ChainConfigurator, bc *BlockChain, engine consensus.Engine) *statePrefetcher {
+func newStatePrefetcher(config ctypes.ChainConfigurator, bc *BlockChain, engine consensus.Engine) *statePrefetcher {
 	return &statePrefetcher{
 		config: config,
 		bc:     bc,
@@ -70,7 +70,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 // precacheTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. The goal is not to execute
 // the transaction successfully, rather to warm up touched data slots.
-func precacheTransaction(config common2.ChainConfigurator, bc ChainContext, author *common.Address, gaspool *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, cfg vm.Config) error {
+func precacheTransaction(config ctypes.ChainConfigurator, bc ChainContext, author *common.Address, gaspool *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, cfg vm.Config) error {
 	// Convert the transaction into an executable message and pre-cache its sender
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number))
 	if err != nil {

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -32,13 +32,13 @@ import (
 //
 // StateProcessor implements Processor.
 type StateProcessor struct {
-	config common2.ChainConfigurator // Chain configuration options
+	config ctypes.ChainConfigurator // Chain configuration options
 	bc     *BlockChain             // Canonical block chain
 	engine consensus.Engine        // Consensus engine used for block rewards
 }
 
 // NewStateProcessor initialises a new StateProcessor.
-func NewStateProcessor(config common2.ChainConfigurator, bc *BlockChain, engine consensus.Engine) *StateProcessor {
+func NewStateProcessor(config ctypes.ChainConfigurator, bc *BlockChain, engine consensus.Engine) *StateProcessor {
 	return &StateProcessor{
 		config: config,
 		bc:     bc,
@@ -85,7 +85,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 // and uses the input parameters for its environment. It returns the receipt
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
-func ApplyTransaction(config common2.ChainConfigurator, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
+func ApplyTransaction(config ctypes.ChainConfigurator, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number))
 	if err != nil {
 		return nil, err

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 const (
@@ -210,7 +210,7 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 // two states over time as they are received and processed.
 type TxPool struct {
 	config      TxPoolConfig
-	chainconfig common2.ChainConfigurator
+	chainconfig ctypes.ChainConfigurator
 	chain       blockChain
 	gasPrice    *big.Int
 	txFeed      event.Feed
@@ -250,7 +250,7 @@ type txpoolResetRequest struct {
 
 // NewTxPool creates a new transaction pool to gather, sort and filter inbound
 // transactions from the network.
-func NewTxPool(config TxPoolConfig, chainconfig common2.ChainConfigurator, chain blockChain) *TxPool {
+func NewTxPool(config TxPoolConfig, chainconfig ctypes.ChainConfigurator, chain blockChain) *TxPool {
 	// Sanitize the input to ensure no vulnerable gas prices are set
 	config = (&config).sanitize()
 

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -294,7 +294,7 @@ func (r Receipts) GetRlp(i int) []byte {
 
 // DeriveFields fills the receipts with their computed fields based on consensus
 // data and contextual infos like containing block and transactions.
-func (r Receipts) DeriveFields(config common2.ChainConfigurator, hash common.Hash, number uint64, txs Transactions) error {
+func (r Receipts) DeriveFields(config ctypes.ChainConfigurator, hash common.Hash, number uint64, txs Transactions) error {
 	signer := MakeSigner(config, new(big.Int).SetUint64(number))
 
 	logIndex := uint(0)

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 var (
@@ -39,7 +39,7 @@ type sigCache struct {
 }
 
 // MakeSigner returns a Signer based on the given chain config and block number.
-func MakeSigner(config common2.ChainConfigurator, blockNumber *big.Int) Signer {
+func MakeSigner(config ctypes.ChainConfigurator, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
 	case config.IsForked(config.GetEIP155Transition, blockNumber):

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/blake2b"
 	"github.com/ethereum/go-ethereum/crypto/bn256"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"golang.org/x/crypto/ripemd160"
 )
@@ -48,7 +48,7 @@ var basePrecompiledContracts = map[common.Address]PrecompiledContract{
 }
 
 // PrecompiledContractsForConfig returns a map containing valid precompiled contracts for a given point in a chain config.
-func PrecompiledContractsForConfig(config common2.ChainConfigurator, bn *big.Int) map[common.Address]PrecompiledContract {
+func PrecompiledContractsForConfig(config ctypes.ChainConfigurator, bn *big.Int) map[common.Address]PrecompiledContract {
 	// Copying to a new map is necessary because assigning to the original map
 	// creates a memory reference. Further, setting the vals to nil in case of nonconfiguration causes
 	// a panic during tests because they run asynchronously (also a valid reason for using an explicit copy).

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/params"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -461,12 +461,12 @@ func TestIsPrecompiledContractEnabled(t *testing.T) {
 	}
 	type c struct {
 		addr     common.Address
-		config   common2.ChainConfigurator
+		config   ctypes.ChainConfigurator
 		blockNum *big.Int
 		want     bool
 	}
 	cases := []c{}
-	addCaseWhere := func(config common2.ChainConfigurator, addr common.Address, bn *big.Int, want bool) {
+	addCaseWhere := func(config ctypes.ChainConfigurator, addr common.Address, bn *big.Int, want bool) {
 		cases = append(cases, c{
 			addr:     addr,
 			config:   config,

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -106,7 +106,7 @@ type EVM struct {
 	depth int
 
 	// chainConfig contains information about the current chain
-	chainConfig common2.ChainConfigurator
+	chainConfig ctypes.ChainConfigurator
 	// virtual machine configuration options used to initialise the
 	// evm.
 	vmConfig Config
@@ -125,7 +125,7 @@ type EVM struct {
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
 // only ever be used *once*.
-func NewEVM(ctx Context, statedb StateDB, chainConfig common2.ChainConfigurator, vmConfig Config) *EVM {
+func NewEVM(ctx Context, statedb StateDB, chainConfig ctypes.ChainConfigurator, vmConfig Config) *EVM {
 	evm := &EVM{
 		Context:      ctx,
 		StateDB:      statedb,
@@ -459,4 +459,4 @@ func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *
 }
 
 // ChainConfig returns the environment's chain configuration
-func (evm *EVM) ChainConfig() common2.ChainConfigurator { return evm.chainConfig }
+func (evm *EVM) ChainConfig() ctypes.ChainConfigurator { return evm.chainConfig }

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -60,7 +60,7 @@ type JumpTable [256]operation
 
 // instructionSetForConfig determines an instruction set for the vm using
 // the chain config params and a current block number
-func instructionSetForConfig(config common.ChainConfigurator, bn *big.Int) JumpTable {
+func instructionSetForConfig(config ctypes.ChainConfigurator, bn *big.Int) JumpTable {
 	instructionSet := newBaseInstructionSet()
 
 	// Homestead

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -26,14 +26,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
 // Config is a basic type specifying certain configuration flags for running
 // the EVM.
 type Config struct {
-	ChainConfig common2.ChainConfigurator
+	ChainConfig ctypes.ChainConfigurator
 	Difficulty  *big.Int
 	Origin      common.Address
 	Coinbase    common.Address

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -34,7 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -47,7 +47,7 @@ type EthAPIBackend struct {
 }
 
 // MultiGethChainConfig returns the active chain configuration.
-func (b *EthAPIBackend) ChainConfig() common2.ChainConfigurator {
+func (b *EthAPIBackend) ChainConfig() ctypes.ChainConfigurator {
 	return b.eth.blockchain.Config()
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -50,7 +50,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/params"
 	paramtypes "github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -140,7 +140,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		return nil, err
 	}
 	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis)
-	if _, ok := genesisErr.(*common2.ConfigCompatError); genesisErr != nil && !ok {
+	if _, ok := genesisErr.(*ctypes.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
 	log.Info("Initialised chain configuration", "config", chainConfig)
@@ -193,7 +193,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		return nil, err
 	}
 	// Rewind the chain in case of an incompatible config upgrade.
-	if compat, ok := genesisErr.(*common2.ConfigCompatError); ok {
+	if compat, ok := genesisErr.(*ctypes.ConfigCompatError); ok {
 		log.Warn("Rewinding chain to upgrade configuration", "err", compat)
 		eth.blockchain.SetHead(compat.RewindTo)
 		rawdb.WriteChainConfig(chainDb, genesisHash, chainConfig)
@@ -249,7 +249,7 @@ func makeExtraData(extra []byte) []byte {
 }
 
 // CreateConsensusEngine creates the required type of consensus engine instance for an Ethereum service
-func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig common2.ChainConfigurator, config *ethash.Config, notify []string, noverify bool, db ethdb.Database) consensus.Engine {
+func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig ctypes.ChainConfigurator, config *ethash.Config, notify []string, noverify bool, db ethdb.Database) consensus.Engine {
 	// If proof-of-authority is requested, set it up
 	if chainConfig.GetConsensusEngineType().IsClique() {
 		return clique.New(&goethereum.CliqueConfig{

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -103,7 +103,7 @@ type ProtocolManager struct {
 
 // NewProtocolManager returns a new Ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
 // with the Ethereum network.
-func NewProtocolManager(config common2.ChainConfigurator, checkpoint *goethereum.TrustedCheckpoint, mode downloader.SyncMode, networkID uint64, mux *event.TypeMux, txpool txPool, engine consensus.Engine, blockchain *core.BlockChain, chaindb ethdb.Database, cacheLimit int, whitelist map[uint64]common.Hash) (*ProtocolManager, error) {
+func NewProtocolManager(config ctypes.ChainConfigurator, checkpoint *goethereum.TrustedCheckpoint, mode downloader.SyncMode, networkID uint64, mux *event.TypeMux, txpool txPool, engine consensus.Engine, blockchain *core.BlockChain, chaindb ethdb.Database, cacheLimit int, whitelist map[uint64]common.Hash) (*ProtocolManager, error) {
 	// Create the protocol manager with the base fields
 	manager := &ProtocolManager{
 		networkID:   networkID,
@@ -830,7 +830,7 @@ type NodeInfo struct {
 	Network    uint64                    `json:"network"`    // Ethereum network ID (1=Frontier, 2=Morden, Ropsten=3, Rinkeby=4, Kotti=6)
 	Difficulty *big.Int                  `json:"difficulty"` // Total difficulty of the host's blockchain
 	Genesis    common.Hash               `json:"genesis"`    // SHA3 hash of the host's genesis block
-	Config     common2.ChainConfigurator `json:"config"`     // Chain configuration for the fork rules
+	Config     ctypes.ChainConfigurator `json:"config"`     // Chain configuration for the fork rules
 	Head       common.Hash               `json:"head"`       // SHA3 hash of the host's best owned block
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -82,7 +82,7 @@ type Backend interface {
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 
-	ChainConfig() common2.ChainConfigurator
+	ChainConfig() ctypes.ChainConfigurator
 	CurrentBlock() *types.Block
 }
 

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/light"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -46,7 +46,7 @@ type LesApiBackend struct {
 	gpo           *gasprice.Oracle
 }
 
-func (b *LesApiBackend) ChainConfig() common2.ChainConfigurator {
+func (b *LesApiBackend) ChainConfig() ctypes.ChainConfigurator {
 	return b.eth.chainConfig
 }
 

--- a/les/client.go
+++ b/les/client.go
@@ -42,7 +42,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/params"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -75,7 +75,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		return nil, err
 	}
 	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis)
-	if _, isCompat := genesisErr.(*common2.ConfigCompatError); genesisErr != nil && !isCompat {
+	if _, isCompat := genesisErr.(*ctypes.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr
 	}
 	log.Info("Initialised chain configuration", "config", chainConfig)
@@ -137,7 +137,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		leth.blockchain.DisableCheckFreq()
 	}
 	// Rewind the chain in case of an incompatible config upgrade.
-	if compat, ok := genesisErr.(*common2.ConfigCompatError); ok {
+	if compat, ok := genesisErr.(*ctypes.ConfigCompatError); ok {
 		log.Warn("Rewinding chain to upgrade configuration", "err", compat)
 		leth.blockchain.SetHead(compat.RewindTo)
 		rawdb.WriteChainConfig(chainDb, genesisHash, chainConfig)

--- a/les/commons.go
+++ b/les/commons.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/ethereum/go-ethereum/p2p/enode"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -58,7 +58,7 @@ type chainReader interface {
 type lesCommons struct {
 	genesis                      common.Hash
 	config                       *eth.Config
-	chainConfig                  common2.ChainConfigurator
+	chainConfig                  ctypes.ChainConfigurator
 	iConfig                      *light.IndexerConfig
 	chainDb                      ethdb.Database
 	peers                        *peerSet
@@ -76,7 +76,7 @@ type NodeInfo struct {
 	Network    uint64                       `json:"network"`    // Ethereum network ID (1=Frontier, 2=Morden, Ropsten=3, Rinkeby=4)
 	Difficulty *big.Int                     `json:"difficulty"` // Total difficulty of the host's blockchain
 	Genesis    common.Hash                  `json:"genesis"`    // SHA3 hash of the host's genesis block
-	Config     common2.ChainConfigurator      `json:"config"`     // Chain configuration for the fork rules
+	Config     ctypes.ChainConfigurator      `json:"config"`     // Chain configuration for the fork rules
 	Head       common.Hash                  `json:"head"`       // SHA3 hash of the host's best owned block
 	CHT        goethereum.TrustedCheckpoint `json:"cht"`        // Trused CHT checkpoint for fast catchup
 }

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -32,16 +32,16 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/light"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-type odrTestFn func(ctx context.Context, db ethdb.Database, config common2.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte
+type odrTestFn func(ctx context.Context, db ethdb.Database, config ctypes.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte
 
 func TestOdrGetBlockLes2(t *testing.T) { testOdr(t, 2, 1, true, odrGetBlock) }
 func TestOdrGetBlockLes3(t *testing.T) { testOdr(t, 3, 1, true, odrGetBlock) }
 
-func odrGetBlock(ctx context.Context, db ethdb.Database, config common2.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
+func odrGetBlock(ctx context.Context, db ethdb.Database, config ctypes.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var block *types.Block
 	if bc != nil {
 		block = bc.GetBlockByHash(bhash)
@@ -58,7 +58,7 @@ func odrGetBlock(ctx context.Context, db ethdb.Database, config common2.ChainCon
 func TestOdrGetReceiptsLes2(t *testing.T) { testOdr(t, 2, 1, true, odrGetReceipts) }
 func TestOdrGetReceiptsLes3(t *testing.T) { testOdr(t, 3, 1, true, odrGetReceipts) }
 
-func odrGetReceipts(ctx context.Context, db ethdb.Database, config common2.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
+func odrGetReceipts(ctx context.Context, db ethdb.Database, config ctypes.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var receipts types.Receipts
 	if bc != nil {
 		if number := rawdb.ReadHeaderNumber(db, bhash); number != nil {
@@ -79,7 +79,7 @@ func odrGetReceipts(ctx context.Context, db ethdb.Database, config common2.Chain
 func TestOdrAccountsLes2(t *testing.T) { testOdr(t, 2, 1, true, odrAccounts) }
 func TestOdrAccountsLes3(t *testing.T) { testOdr(t, 3, 1, true, odrAccounts) }
 
-func odrAccounts(ctx context.Context, db ethdb.Database, config common2.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
+func odrAccounts(ctx context.Context, db ethdb.Database, config ctypes.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	dummyAddr := common.HexToAddress("1234567812345678123456781234567812345678")
 	acc := []common.Address{bankAddr, userAddr1, userAddr2, dummyAddr}
 
@@ -114,7 +114,7 @@ type callmsg struct {
 
 func (callmsg) CheckNonce() bool { return false }
 
-func odrContractCall(ctx context.Context, db ethdb.Database, config common2.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
+func odrContractCall(ctx context.Context, db ethdb.Database, config ctypes.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	data := common.Hex2Bytes("60CD26850000000000000000000000000000000000000000000000000000000000000000")
 
 	var res []byte
@@ -158,7 +158,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config common2.Chai
 func TestOdrTxStatusLes2(t *testing.T) { testOdr(t, 2, 1, false, odrTxStatus) }
 func TestOdrTxStatusLes3(t *testing.T) { testOdr(t, 3, 1, false, odrTxStatus) }
 
-func odrTxStatus(ctx context.Context, db ethdb.Database, config common2.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
+func odrTxStatus(ctx context.Context, db ethdb.Database, config ctypes.ChainConfigurator, bc *core.BlockChain, lc *light.LightChain, bhash common.Hash) []byte {
 	var txs types.Transactions
 	if bc != nil {
 		block := bc.GetBlockByHash(bhash)

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/rlp"
 	lru "github.com/hashicorp/golang-lru"
@@ -78,7 +78,7 @@ type LightChain struct {
 // NewLightChain returns a fully initialised light chain using information
 // available in the database. It initialises the default Ethereum header
 // validator.
-func NewLightChain(odr OdrBackend, config common2.ChainConfigurator, engine consensus.Engine, checkpoint *goethereum.TrustedCheckpoint) (*LightChain, error) {
+func NewLightChain(odr OdrBackend, config ctypes.ChainConfigurator, engine consensus.Engine, checkpoint *goethereum.TrustedCheckpoint) (*LightChain, error) {
 	bodyCache, _ := lru.New(bodyCacheLimit)
 	bodyRLPCache, _ := lru.New(bodyCacheLimit)
 	blockCache, _ := lru.New(blockCacheLimit)
@@ -463,7 +463,7 @@ func (lc *LightChain) GetHeaderByNumberOdr(ctx context.Context, number uint64) (
 }
 
 // Config retrieves the header chain's chain configuration.
-func (lc *LightChain) Config() common2.ChainConfigurator { return lc.hc.Config() }
+func (lc *LightChain) Config() ctypes.ChainConfigurator { return lc.hc.Config() }
 
 // SyncCheckpoint fetches the checkpoint point block header according to
 // the checkpoint provided by the remote peer.

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -50,7 +50,7 @@ var txPermanent = uint64(500)
 // always receive all locally signed transactions in the same order as they are
 // created.
 type TxPool struct {
-	config       common2.ChainConfigurator
+	config       ctypes.ChainConfigurator
 	signer       types.Signer
 	quit         chan bool
 	txFeed       event.Feed
@@ -88,7 +88,7 @@ type TxRelayBackend interface {
 }
 
 // NewTxPool creates a new light transaction pool
-func NewTxPool(config common2.ChainConfigurator, chain *LightChain, relay TxRelayBackend) *TxPool {
+func NewTxPool(config ctypes.ChainConfigurator, chain *LightChain, relay TxRelayBackend) *TxPool {
 	pool := &TxPool{
 		config:      config,
 		signer:      types.NewEIP155Signer(config.GetChainID()),

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -67,7 +67,7 @@ type Miner struct {
 	shouldStart int32 // should start indicates whether we should start after sync
 }
 
-func New(eth Backend, config *Config, chainConfig common2.ChainConfigurator, mux *event.TypeMux, engine consensus.Engine, isLocalBlock func(block *types.Block) bool) *Miner {
+func New(eth Backend, config *Config, chainConfig ctypes.ChainConfigurator, mux *event.TypeMux, engine consensus.Engine, isLocalBlock func(block *types.Block) bool) *Miner {
 	miner := &Miner{
 		eth:      eth,
 		mux:      mux,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -33,7 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -124,7 +124,7 @@ type intervalAdjust struct {
 // and gathering the sealing result.
 type worker struct {
 	config      *Config
-	chainConfig common2.ChainConfigurator
+	chainConfig ctypes.ChainConfigurator
 	engine      consensus.Engine
 	eth         Backend
 	chain       *core.BlockChain
@@ -177,7 +177,7 @@ type worker struct {
 	resubmitHook func(time.Duration, time.Duration) // Method to call upon updating resubmitting interval.
 }
 
-func newWorker(config *Config, chainConfig common2.ChainConfigurator, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool) *worker {
+func newWorker(config *Config, chainConfig ctypes.ChainConfigurator, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool) *worker {
 	worker := &worker{
 		config:             config,
 		chainConfig:        chainConfig,

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
@@ -53,8 +53,8 @@ const (
 var (
 	// Test chain configurations
 	testTxPoolConfig  core.TxPoolConfig
-	ethashChainConfig common2.ChainConfigurator
-	cliqueChainConfig common2.ChainConfigurator
+	ethashChainConfig ctypes.ChainConfigurator
+	cliqueChainConfig ctypes.ChainConfigurator
 
 	// Test accounts
 	testBankKey, _  = crypto.GenerateKey()
@@ -80,7 +80,7 @@ func init() {
 	testTxPoolConfig.Journal = ""
 	ethashChainConfig = params.TestChainConfig
 	cliqueChainConfig = params.TestChainConfig
-	cliqueChainConfig.MustSetConsensusEngineType(common2.ConsensusEngineT_Clique)
+	cliqueChainConfig.MustSetConsensusEngineType(ctypes.ConsensusEngineT_Clique)
 	cliqueChainConfig.SetCliquePeriod(10)
 	cliqueChainConfig.SetCliqueEpoch(30000)
 	tx1, _ := types.SignTx(types.NewTransaction(0, testUserAddress, big.NewInt(1000), vars.TxGas, nil, nil), types.HomesteadSigner{}, testBankKey)
@@ -100,7 +100,7 @@ type testWorkerBackend struct {
 	uncleBlock *types.Block
 }
 
-func newTestWorkerBackend(t *testing.T, chainConfig common2.ChainConfigurator, engine consensus.Engine, db ethdb.Database, n int) *testWorkerBackend {
+func newTestWorkerBackend(t *testing.T, chainConfig ctypes.ChainConfigurator, engine consensus.Engine, db ethdb.Database, n int) *testWorkerBackend {
 	var gspec = paramtypes.Genesis{
 		Config: chainConfig,
 		Alloc:  paramtypes.GenesisAlloc{testBankAddress: {Balance: testBankFunds}},
@@ -180,7 +180,7 @@ func (b *testWorkerBackend) newRandomTx(creation bool) *types.Transaction {
 	return tx
 }
 
-func newTestWorker(t *testing.T, chainConfig common2.ChainConfigurator, engine consensus.Engine, db ethdb.Database, blocks int) (*worker, *testWorkerBackend) {
+func newTestWorker(t *testing.T, chainConfig ctypes.ChainConfigurator, engine consensus.Engine, db ethdb.Database, blocks int) (*worker, *testWorkerBackend) {
 	backend := newTestWorkerBackend(t, chainConfig, engine, db, blocks)
 	backend.txPool.AddLocals(pendingTxs)
 	w := newWorker(testConfig, chainConfig, engine, backend, new(event.TypeMux), nil)
@@ -199,7 +199,7 @@ func TestGenerateBlockAndImportClique(t *testing.T) {
 func testGenerateBlockAndImport(t *testing.T, isClique bool) {
 	var (
 		engine      consensus.Engine
-		chainConfig common2.ChainConfigurator
+		chainConfig ctypes.ChainConfigurator
 		db          = rawdb.NewMemoryDatabase()
 	)
 	if isClique {
@@ -286,7 +286,7 @@ func TestPendingStateAndBlockClique(t *testing.T) {
 	}, rawdb.NewMemoryDatabase()))
 }
 
-func testPendingStateAndBlock(t *testing.T, chainConfig common2.ChainConfigurator, engine consensus.Engine) {
+func testPendingStateAndBlock(t *testing.T, chainConfig ctypes.ChainConfigurator, engine consensus.Engine) {
 	defer engine.Close()
 
 	w, b := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), 0)
@@ -321,7 +321,7 @@ func TestEmptyWorkClique(t *testing.T) {
 	}, rawdb.NewMemoryDatabase()))
 }
 
-func testEmptyWork(t *testing.T, chainConfig common2.ChainConfigurator, engine consensus.Engine) {
+func testEmptyWork(t *testing.T, chainConfig ctypes.ChainConfigurator, engine consensus.Engine) {
 	defer engine.Close()
 
 	w, _ := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), 0)
@@ -443,7 +443,7 @@ func TestRegenerateMiningBlockClique(t *testing.T) {
 	}, rawdb.NewMemoryDatabase()))
 }
 
-func testRegenerateMiningBlock(t *testing.T, chainConfig common2.ChainConfigurator, engine consensus.Engine) {
+func testRegenerateMiningBlock(t *testing.T, chainConfig ctypes.ChainConfigurator, engine consensus.Engine) {
 	defer engine.Close()
 
 	w, b := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), 0)
@@ -511,7 +511,7 @@ func TestAdjustIntervalClique(t *testing.T) {
 	}, rawdb.NewMemoryDatabase()))
 }
 
-func testAdjustInterval(t *testing.T, chainConfig common2.ChainConfigurator, engine consensus.Engine) {
+func testAdjustInterval(t *testing.T, chainConfig ctypes.ChainConfigurator, engine consensus.Engine) {
 	defer engine.Close()
 
 	w, _ := newTestWorker(t, chainConfig, engine, rawdb.NewMemoryDatabase(), 0)

--- a/params/config_ethersocial.go
+++ b/params/config_ethersocial.go
@@ -19,7 +19,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -29,7 +29,7 @@ var (
 	EthersocialGenesisHash = common.HexToHash("0x310dd3c4ae84dd89f1b46cfdd5e26c8f904dfddddc73f323b468127272e20e9f")
 
 	// EthersocialChainConfig is the chain parameters to run a node on the Ethersocial main network.
-	EthersocialChainConfig = func() common2.ChainConfigurator {
+	EthersocialChainConfig = func() ctypes.ChainConfigurator {
 		c := &goethereum.ChainConfig{
 			ChainID:             big.NewInt(31102),
 			HomesteadBlock:      big.NewInt(0),
@@ -45,10 +45,10 @@ var (
 		}
 		c.SetNetworkID(&EtherSocialNetworkID)
 		//EthersocialBlock:    big.NewInt(0)
-		c.SetEthashDifficultyBombDelaySchedule(common2.Uint64BigMapEncodesHex{
+		c.SetEthashDifficultyBombDelaySchedule(ctypes.Uint64BigMapEncodesHex{
 			600000: new(big.Int).SetUint64(uint64(0x2dc6c0)),
 		})
-		c.SetEthashBlockRewardSchedule(common2.Uint64BigMapEncodesHex{
+		c.SetEthashBlockRewardSchedule(ctypes.Uint64BigMapEncodesHex{
 			0: big.NewInt(5e+18),
 		})
 		return c

--- a/params/config_kotti.go
+++ b/params/config_kotti.go
@@ -19,7 +19,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -35,7 +35,7 @@ var (
 	//KottiECIP1010PauseBlock        = uint64(0)
 	//KottiECIP1010Length            = uint64(2000000)
 
-	KottiChainConfig = func() common2.ChainConfigurator {
+	KottiChainConfig = func() ctypes.ChainConfigurator {
 		c := &goethereum.ChainConfig{
 			ChainID:             big.NewInt(6),
 			HomesteadBlock:      big.NewInt(0),

--- a/params/config_mix.go
+++ b/params/config_mix.go
@@ -19,7 +19,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -29,7 +29,7 @@ var (
 	MixNetworkID   = uint64(76)
 
 	// MixChainConfig is the chain parameters to run a node on the MIX main network.
-	MixChainConfig = func() common2.ChainConfigurator {
+	MixChainConfig = func() ctypes.ChainConfigurator {
 		c := &goethereum.ChainConfig{
 			ChainID:             big.NewInt(76),
 			Ethash:              new(goethereum.EthashConfig),

--- a/params/config_mordor.go
+++ b/params/config_mordor.go
@@ -19,7 +19,7 @@ import (
 	"math/big"
 
 	paramtypes "github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -31,7 +31,7 @@ var (
 	//MordorEIP160FBlock             = uint64(0)
 
 	// MordorChainConfig is the chain parameters to run a node on the Ethereum Classic Mordor test network (PoW).
-	MordorChainConfig = func() common2.ChainConfigurator {
+	MordorChainConfig = func() ctypes.ChainConfigurator {
 		//c := &goethereum.ChainConfig{
 		//	ChainID:             big.NewInt(63),
 		//	HomesteadBlock:      big.NewInt(0),

--- a/params/config_social.go
+++ b/params/config_social.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -43,7 +43,7 @@ var (
 		ECIP1017FBlock:    big.NewInt(5000000),
 		ECIP1017EraRounds: big.NewInt(5000000),
 		EIP160FBlock:      big.NewInt(0),
-		BlockRewardSchedule: common2.Uint64BigMapEncodesHex{
+		BlockRewardSchedule: ctypes.Uint64BigMapEncodesHex{
 			0: new(big.Int).Mul(big.NewInt(50), big.NewInt(1e+18)),
 		},
 		RequireBlockHashes: map[uint64]common.Hash{

--- a/params/config_test.go
+++ b/params/config_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params/convert"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -33,9 +33,9 @@ func uint64P(n uint64) *uint64 {
 
 func TestCheckCompatible(t *testing.T) {
 	type test struct {
-		stored, new common2.ChainConfigurator
+		stored, new ctypes.ChainConfigurator
 		head        uint64
-		wantErr     *common2.ConfigCompatError
+		wantErr     *ctypes.ConfigCompatError
 	}
 	tests := []test{
 		{stored: AllEthashProtocolChanges, new: AllEthashProtocolChanges, head: 0, wantErr: nil},
@@ -50,7 +50,7 @@ func TestCheckCompatible(t *testing.T) {
 			stored: AllEthashProtocolChanges,
 			new:    &goethereum.ChainConfig{HomesteadBlock: nil},
 			head:   3,
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "Homestead fork block",
 				StoredConfig: uint64P(0),
 				NewConfig:    nil,
@@ -61,7 +61,7 @@ func TestCheckCompatible(t *testing.T) {
 			stored: AllEthashProtocolChanges,
 			new:    &goethereum.ChainConfig{HomesteadBlock: big.NewInt(1)},
 			head:   3,
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "Homestead fork block",
 				StoredConfig: uint64P(0),
 				NewConfig:    uint64P(1),
@@ -72,7 +72,7 @@ func TestCheckCompatible(t *testing.T) {
 			stored: &goethereum.ChainConfig{HomesteadBlock: big.NewInt(30), EIP150Block: big.NewInt(10)},
 			new:    &goethereum.ChainConfig{HomesteadBlock: big.NewInt(25), EIP150Block: big.NewInt(20)},
 			head:   25,
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "EIP150 fork block",
 				StoredConfig: uint64P(10),
 				NewConfig:    uint64P(20),
@@ -83,7 +83,7 @@ func TestCheckCompatible(t *testing.T) {
 			stored: &paramtypes.MultiGethChainConfig{EIP100FBlock: big.NewInt(30), EIP649FBlock: big.NewInt(30)},
 			new:    &paramtypes.MultiGethChainConfig{EIP100FBlock: big.NewInt(24), EIP649FBlock: big.NewInt(24)},
 			head:   25,
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "EIP100F fork block",
 				StoredConfig: uint64P(30),
 				NewConfig:    uint64P(24),
@@ -104,14 +104,14 @@ func TestCheckCompatible(t *testing.T) {
 		},
 		{
 			stored: MainnetChainConfig,
-			new: func() common2.ChainConfigurator {
+			new: func() ctypes.ChainConfigurator {
 				c := &goethereum.ChainConfig{}
 				convert.Convert(MainnetChainConfig, c)
 				c.SetEthashEIP779Transition(uint64P(1900000))
 				return c
 			}(),
 			head: MainnetChainConfig.DAOForkBlock.Uint64(),
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "DAO fork support flag",
 				StoredConfig: uint64P(MainnetChainConfig.DAOForkBlock.Uint64()),
 				NewConfig:    uint64P(1900000),
@@ -120,14 +120,14 @@ func TestCheckCompatible(t *testing.T) {
 		},
 		{
 			stored: MainnetChainConfig,
-			new: func() common2.ChainConfigurator {
+			new: func() ctypes.ChainConfigurator {
 				c := &goethereum.ChainConfig{}
 				convert.Convert(MainnetChainConfig, c)
 				c.SetEthashEIP779Transition(nil)
 				return c
 			}(),
 			head: MainnetChainConfig.DAOForkBlock.Uint64(),
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "DAO fork support flag",
 				StoredConfig: uint64P(MainnetChainConfig.DAOForkBlock.Uint64()),
 				NewConfig:    nil,
@@ -136,14 +136,14 @@ func TestCheckCompatible(t *testing.T) {
 		},
 		{
 			stored: MainnetChainConfig,
-			new: func() common2.ChainConfigurator {
+			new: func() ctypes.ChainConfigurator {
 				c := &goethereum.ChainConfig{}
 				*c = *MainnetChainConfig
 				c.SetChainID(new(big.Int).Sub(MainnetChainConfig.EIP155Block, common.Big1))
 				return c
 			}(),
 			head: MainnetChainConfig.EIP158Block.Uint64(),
-			wantErr: &common2.ConfigCompatError{
+			wantErr: &ctypes.ConfigCompatError{
 				What:         "EIP155 chain ID",
 				StoredConfig: uint64P(MainnetChainConfig.EIP155Block.Uint64()),
 				NewConfig:    uint64P(MainnetChainConfig.EIP155Block.Uint64()),
@@ -153,7 +153,7 @@ func TestCheckCompatible(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := common2.Compatible(&test.head, test.stored, test.new)
+		err := ctypes.Compatible(&test.head, test.stored, test.new)
 		if (err == nil && test.wantErr != nil) || (err != nil && test.wantErr == nil) {
 			t.Errorf("nil/nonnil, error mismatch:\nstored: %v\nnew: %v\nhead: %v\nerr: %v\nwant: %v", test.stored, test.new, test.head, err, test.wantErr)
 		} else if err != nil && (err.RewindTo != test.wantErr.RewindTo) {

--- a/params/convert/convert_test.go
+++ b/params/convert/convert_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
 	"github.com/ethereum/go-ethereum/params/types/aleth"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/types/parity"
 )
@@ -80,7 +80,7 @@ func TestConvert(t *testing.T) {
 		t.Error(err)
 	}
 
-	if diffs := Equal(reflect.TypeOf((*common.Configurator)(nil)), &spec, &spec2); len(diffs) != 0 {
+	if diffs := Equal(reflect.TypeOf((*ctypes.Configurator)(nil)), &spec, &spec2); len(diffs) != 0 {
 		for _, diff := range diffs {
 			t.Error("not equal", diff.Field, diff.A, diff.B)
 		}
@@ -92,7 +92,7 @@ func TestIdentical(t *testing.T) {
 		"ChainID",
 		"NetworkID",
 	}
-	configs :=  []common.ChainConfigurator{
+	configs :=  []ctypes.ChainConfigurator{
 		&paramtypes.MultiGethChainConfig{},
 		&goethereum.ChainConfig{},
 		&parity.ParityChainSpec{},
@@ -124,26 +124,26 @@ func TestConfiguratorImplementationsSatisfied(t *testing.T) {
 	for _, ty := range []interface{}{
 		&parity.ParityChainSpec{},
 	} {
-		_ = ty.(common.Configurator)
+		_ = ty.(ctypes.Configurator)
 	}
 
 	for _, ty := range []interface{}{
 		&goethereum.ChainConfig{},
 		&paramtypes.MultiGethChainConfig{},
 	} {
-		_ = ty.(common.ChainConfigurator)
+		_ = ty.(ctypes.ChainConfigurator)
 	}
 
 	for _, ty := range []interface{}{
 		&paramtypes.Genesis{},
 	} {
-		_ = ty.(common.GenesisBlocker)
+		_ = ty.(ctypes.GenesisBlocker)
 	}
 }
 
 func TestCompatible(t *testing.T) {
 	spec := &parity.ParityChainSpec{}
-	fns, names := common.Transitions(spec)
+	fns, names := ctypes.Transitions(spec)
 	for i, fn := range fns {
 		t.Log(names[i], fn())
 	}
@@ -169,7 +169,7 @@ func TestGatherForks(t *testing.T) {
 		return false
 	}
 	for ci, c := range cases {
-		gotForkNs := common.Forks(c.config)
+		gotForkNs := ctypes.Forks(c.config)
 		if len(gotForkNs) != len(c.wantNs) {
 			for _, n := range c.wantNs {
 				if !sliceContains(gotForkNs, n) {

--- a/params/convert/generic.go
+++ b/params/convert/generic.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	paramtypes "github.com/ethereum/go-ethereum/params/types"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/types/parity"
 	"github.com/ethereum/go-ethereum/params/vars"
@@ -33,10 +33,10 @@ import (
 // itself because they are chain-aware, or fit nuanced, or adhoc, use cases and should
 // not be demanded of EVM-based ecosystem logic as a whole. Debatable. NOTE.
 type GenericCC struct {
-	common.ChainConfigurator
+	ctypes.ChainConfigurator
 }
 
-func AsGenericCC(c common.ChainConfigurator) GenericCC {
+func AsGenericCC(c ctypes.ChainConfigurator) GenericCC {
 	return GenericCC{c}
 }
 

--- a/params/convert/json.go
+++ b/params/convert/json.go
@@ -21,12 +21,12 @@ import (
 	"encoding/json"
 
 	paramtypes "github.com/ethereum/go-ethereum/params/types"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/types/parity"
 )
 
-func UnmarshalChainConfigurator(input []byte) (common.ChainConfigurator, error) {
+func UnmarshalChainConfigurator(input []byte) (ctypes.ChainConfigurator, error) {
 	var map1 = make(map[string]interface{})
 	err := json.Unmarshal(input, &map1)
 	if err != nil {

--- a/params/types/chain_config.go
+++ b/params/types/chain_config.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -175,8 +175,8 @@ type MultiGethChainConfig struct {
 	TrustedCheckpoint       *goethereum.TrustedCheckpoint      `json:"trustedCheckpoint"`
 	TrustedCheckpointOracle *goethereum.CheckpointOracleConfig `json:"trustedCheckpointOracle"`
 
-	DifficultyBombDelaySchedule common2.Uint64BigMapEncodesHex `json:"difficultyBombDelays,omitempty"'` // JSON tag matches Parity's
-	BlockRewardSchedule         common2.Uint64BigMapEncodesHex `json:"blockReward,omitempty"`           // JSON tag matches Parity's
+	DifficultyBombDelaySchedule ctypes.Uint64BigMapEncodesHex `json:"difficultyBombDelays,omitempty"'` // JSON tag matches Parity's
+	BlockRewardSchedule         ctypes.Uint64BigMapEncodesHex `json:"blockReward,omitempty"`           // JSON tag matches Parity's
 
 	RequireBlockHashes map[uint64]common.Hash `json:"requireBlockHashes"`
 }

--- a/params/types/chain_config_configurator.go
+++ b/params/types/chain_config_configurator.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
@@ -76,7 +76,7 @@ func (c *MultiGethChainConfig) GetNetworkID() *uint64 {
 
 func (c *MultiGethChainConfig) SetNetworkID(n *uint64) error {
 	if n == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.NetworkID = *n
 	return nil
@@ -351,26 +351,26 @@ func (c *MultiGethChainConfig) GetForkCanonHashes() map[uint64]common.Hash {
 	return c.RequireBlockHashes
 }
 
-func (c *MultiGethChainConfig) GetConsensusEngineType() common2.ConsensusEngineT {
+func (c *MultiGethChainConfig) GetConsensusEngineType() ctypes.ConsensusEngineT {
 	if c.Ethash != nil {
-		return common2.ConsensusEngineT_Ethash
+		return ctypes.ConsensusEngineT_Ethash
 	}
 	if c.Clique != nil {
-		return common2.ConsensusEngineT_Clique
+		return ctypes.ConsensusEngineT_Clique
 	}
-	return common2.ConsensusEngineT_Unknown
+	return ctypes.ConsensusEngineT_Unknown
 }
 
-func (c *MultiGethChainConfig) MustSetConsensusEngineType(t common2.ConsensusEngineT) error {
+func (c *MultiGethChainConfig) MustSetConsensusEngineType(t ctypes.ConsensusEngineT) error {
 	switch t {
-	case common2.ConsensusEngineT_Ethash:
+	case ctypes.ConsensusEngineT_Ethash:
 		c.Ethash = new(goethereum.EthashConfig)
 		return nil
-	case common2.ConsensusEngineT_Clique:
+	case ctypes.ConsensusEngineT_Clique:
 		c.Clique = new(goethereum.CliqueConfig)
 		return nil
 	default:
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 }
 
@@ -425,7 +425,7 @@ func (c *MultiGethChainConfig) GetEthashEIP779Transition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashEIP779Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.DAOForkBlock = setBig(c.DAOForkBlock, n)
 	return nil
@@ -442,9 +442,9 @@ func (c *MultiGethChainConfig) GetEthashEIP649Transition() *uint64 {
 		c.eip649FInferred = true
 	}()
 
-	diffN = common2.ExtractHostageSituationN(
+	diffN = ctypes.ExtractHostageSituationN(
 		c.DifficultyBombDelaySchedule,
-		common2.Uint64BigMapEncodesHex(c.BlockRewardSchedule),
+		ctypes.Uint64BigMapEncodesHex(c.BlockRewardSchedule),
 		vars.EIP649DifficultyBombDelay,
 		vars.EIP649FBlockReward,
 	)
@@ -453,7 +453,7 @@ func (c *MultiGethChainConfig) GetEthashEIP649Transition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashEIP649Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 
 	c.EIP649FBlock = setBig(c.EIP649FBlock, n)
@@ -464,10 +464,10 @@ func (c *MultiGethChainConfig) SetEthashEIP649Transition(n *uint64) error {
 	}
 
 	if c.BlockRewardSchedule == nil {
-		c.BlockRewardSchedule = common2.Uint64BigMapEncodesHex{}
+		c.BlockRewardSchedule = ctypes.Uint64BigMapEncodesHex{}
 	}
 	if c.DifficultyBombDelaySchedule == nil {
-		c.DifficultyBombDelaySchedule = common2.Uint64BigMapEncodesHex{}
+		c.DifficultyBombDelaySchedule = ctypes.Uint64BigMapEncodesHex{}
 	}
 
 	c.BlockRewardSchedule[*n] = vars.EIP649FBlockReward
@@ -492,7 +492,7 @@ func (c *MultiGethChainConfig) GetEthashEIP1234Transition() *uint64 {
 		c.eip1234FInferred = true
 	}()
 
-	diffN = common2.ExtractHostageSituationN(
+	diffN = ctypes.ExtractHostageSituationN(
 		c.DifficultyBombDelaySchedule,
 		c.BlockRewardSchedule,
 		vars.EIP1234DifficultyBombDelay,
@@ -503,7 +503,7 @@ func (c *MultiGethChainConfig) GetEthashEIP1234Transition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashEIP1234Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 
 	c.EIP1234FBlock = setBig(c.EIP1234FBlock, n)
@@ -514,10 +514,10 @@ func (c *MultiGethChainConfig) SetEthashEIP1234Transition(n *uint64) error {
 	}
 
 	if c.BlockRewardSchedule == nil {
-		c.BlockRewardSchedule = common2.Uint64BigMapEncodesHex{}
+		c.BlockRewardSchedule = ctypes.Uint64BigMapEncodesHex{}
 	}
 	if c.DifficultyBombDelaySchedule == nil {
-		c.DifficultyBombDelaySchedule = common2.Uint64BigMapEncodesHex{}
+		c.DifficultyBombDelaySchedule = ctypes.Uint64BigMapEncodesHex{}
 	}
 
 	// Block reward is a simple lookup; doesn't matter if overwrite or not.
@@ -542,7 +542,7 @@ func (c *MultiGethChainConfig) GetEthashECIP1010PauseTransition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashECIP1010PauseTransition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	if c.ECIP1010PauseBlock == nil && c.ECIP1010Length != nil {
 		c.ECIP1010PauseBlock = setBig(c.ECIP1010PauseBlock, n)
@@ -566,11 +566,11 @@ func (c *MultiGethChainConfig) GetEthashECIP1010ContinueTransition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashECIP1010ContinueTransition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	// length = continue - pause
 	if n == nil {
-		return common2.ErrUnsupportedConfigNoop
+		return ctypes.ErrUnsupportedConfigNoop
 	}
 	if c.ECIP1010PauseBlock == nil {
 		c.ECIP1010Length = new(big.Int).SetUint64(*n)
@@ -586,7 +586,7 @@ func (c *MultiGethChainConfig) GetEthashECIP1017Transition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashECIP1017Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.ECIP1017FBlock = setBig(c.ECIP1017FBlock, n)
 	return nil
@@ -598,7 +598,7 @@ func (c *MultiGethChainConfig) GetEthashECIP1017EraRounds() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashECIP1017EraRounds(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.ECIP1017EraRounds = setBig(c.ECIP1017EraRounds, n)
 	return nil
@@ -610,7 +610,7 @@ func (c *MultiGethChainConfig) GetEthashEIP100BTransition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashEIP100BTransition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.EIP100FBlock = setBig(c.EIP100FBlock, n)
 	return nil
@@ -622,31 +622,31 @@ func (c *MultiGethChainConfig) GetEthashECIP1041Transition() *uint64 {
 
 func (c *MultiGethChainConfig) SetEthashECIP1041Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.DisposalBlock = setBig(c.DisposalBlock, n)
 	return nil
 }
 
-func (c *MultiGethChainConfig) GetEthashDifficultyBombDelaySchedule() common2.Uint64BigMapEncodesHex {
+func (c *MultiGethChainConfig) GetEthashDifficultyBombDelaySchedule() ctypes.Uint64BigMapEncodesHex {
 	return c.DifficultyBombDelaySchedule
 }
 
-func (c *MultiGethChainConfig) SetEthashDifficultyBombDelaySchedule(m common2.Uint64BigMapEncodesHex) error {
+func (c *MultiGethChainConfig) SetEthashDifficultyBombDelaySchedule(m ctypes.Uint64BigMapEncodesHex) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.DifficultyBombDelaySchedule = m
 	return nil
 }
 
-func (c *MultiGethChainConfig) GetEthashBlockRewardSchedule() common2.Uint64BigMapEncodesHex {
+func (c *MultiGethChainConfig) GetEthashBlockRewardSchedule() ctypes.Uint64BigMapEncodesHex {
 	return c.BlockRewardSchedule
 }
 
-func (c *MultiGethChainConfig) SetEthashBlockRewardSchedule(m common2.Uint64BigMapEncodesHex) error {
+func (c *MultiGethChainConfig) SetEthashBlockRewardSchedule(m ctypes.Uint64BigMapEncodesHex) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.BlockRewardSchedule = m
 	return nil
@@ -661,7 +661,7 @@ func (c *MultiGethChainConfig) GetCliquePeriod() uint64 {
 
 func (c *MultiGethChainConfig) SetCliquePeriod(n uint64) error {
 	if c.Clique == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.Clique.Period = n
 	return nil
@@ -676,7 +676,7 @@ func (c *MultiGethChainConfig) GetCliqueEpoch() uint64 {
 
 func (c *MultiGethChainConfig) SetCliqueEpoch(n uint64) error {
 	if c.Clique == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.Clique.Epoch = n
 	return nil

--- a/params/types/ctypes/configurator.go
+++ b/params/types/ctypes/configurator.go
@@ -15,7 +15,7 @@
 // along with the multi-geth library. If not, see <http://www.gnu.org/licenses/>.
 
 
-package common
+package ctypes
 
 import (
 	"fmt"

--- a/params/types/ctypes/configurator_iface.go
+++ b/params/types/ctypes/configurator_iface.go
@@ -15,7 +15,7 @@
 // along with the multi-geth library. If not, see <http://www.gnu.org/licenses/>.
 
 
-package common
+package ctypes
 
 import (
 	"math/big"

--- a/params/types/ctypes/configurator_test.go
+++ b/params/types/ctypes/configurator_test.go
@@ -15,7 +15,7 @@
 // along with the multi-geth library. If not, see <http://www.gnu.org/licenses/>.
 
 
-package common
+package ctypes
 
 import (
 	"testing"

--- a/params/types/ctypes/ethash_reward.go
+++ b/params/types/ctypes/ethash_reward.go
@@ -15,7 +15,7 @@
 // along with the multi-geth library. If not, see <http://www.gnu.org/licenses/>.
 
 
-package common
+package ctypes
 
 import (
 	"math/big"

--- a/params/types/ctypes/types.go
+++ b/params/types/ctypes/types.go
@@ -15,7 +15,7 @@
 // along with the multi-geth library. If not, see <http://www.gnu.org/licenses/>.
 
 
-package common
+package ctypes
 
 import (
 	"encoding/json"

--- a/params/types/ctypes/types_test.go
+++ b/params/types/ctypes/types_test.go
@@ -15,7 +15,7 @@
 // along with the multi-geth library. If not, see <http://www.gnu.org/licenses/>.
 
 
-package common
+package ctypes
 
 import (
 	"bytes"

--- a/params/types/gen_genesis.go
+++ b/params/types/gen_genesis.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	common0 "github.com/ethereum/go-ethereum/params/types/common"
+	common0 "github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 

--- a/params/types/genesis.go
+++ b/params/types/genesis.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -43,7 +43,7 @@ var ErrGenesisNoConfig = errors.New("genesis has no chain configuration")
 // Genesis specifies the header fields, state of a genesis block. It also defines hard
 // fork switch-over blocks through the chain configuration.
 type Genesis struct {
-	Config     common2.ChainConfigurator `json:"config"`
+	Config     ctypes.ChainConfigurator `json:"config"`
 	Nonce      uint64                    `json:"nonce"`
 	Timestamp  uint64                    `json:"timestamp"`
 	ExtraData  []byte                    `json:"extraData"`
@@ -175,15 +175,15 @@ func DecodePreAlloc(data string) GenesisAlloc {
 	return ga
 }
 
-// Following methods implement the common2.GenesisBlocker interface.
+// Following methods implement the ctypes.GenesisBlocker interface.
 
-func (g *Genesis) GetSealingType() common2.BlockSealingT {
-	return common2.BlockSealing_Ethereum
+func (g *Genesis) GetSealingType() ctypes.BlockSealingT {
+	return ctypes.BlockSealing_Ethereum
 }
 
-func (g *Genesis) SetSealingType(t common2.BlockSealingT) error {
-	if t != common2.BlockSealing_Ethereum {
-		return common2.ErrUnsupportedConfigFatal
+func (g *Genesis) SetSealingType(t ctypes.BlockSealingT) error {
+	if t != ctypes.BlockSealing_Ethereum {
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	return nil
 }
@@ -535,11 +535,11 @@ func (g *Genesis) GetForkCanonHashes() map[uint64]common.Hash {
 	return g.Config.GetForkCanonHashes()
 }
 
-func (g *Genesis) GetConsensusEngineType() common2.ConsensusEngineT {
+func (g *Genesis) GetConsensusEngineType() ctypes.ConsensusEngineT {
 	return g.Config.GetConsensusEngineType()
 }
 
-func (g *Genesis) MustSetConsensusEngineType(t common2.ConsensusEngineT) error {
+func (g *Genesis) MustSetConsensusEngineType(t ctypes.ConsensusEngineT) error {
 	return g.Config.MustSetConsensusEngineType(t)
 }
 
@@ -655,19 +655,19 @@ func (g *Genesis) SetEthashECIP1041Transition(n *uint64) error {
 	return g.Config.SetEthashECIP1041Transition(n)
 }
 
-func (g *Genesis) GetEthashDifficultyBombDelaySchedule() common2.Uint64BigMapEncodesHex {
+func (g *Genesis) GetEthashDifficultyBombDelaySchedule() ctypes.Uint64BigMapEncodesHex {
 	return g.Config.GetEthashDifficultyBombDelaySchedule()
 }
 
-func (g *Genesis) SetEthashDifficultyBombDelaySchedule(m common2.Uint64BigMapEncodesHex) error {
+func (g *Genesis) SetEthashDifficultyBombDelaySchedule(m ctypes.Uint64BigMapEncodesHex) error {
 	return g.Config.SetEthashDifficultyBombDelaySchedule(m)
 }
 
-func (g *Genesis) GetEthashBlockRewardSchedule() common2.Uint64BigMapEncodesHex {
+func (g *Genesis) GetEthashBlockRewardSchedule() ctypes.Uint64BigMapEncodesHex {
 	return g.Config.GetEthashBlockRewardSchedule()
 }
 
-func (g *Genesis) SetEthashBlockRewardSchedule(m common2.Uint64BigMapEncodesHex) error {
+func (g *Genesis) SetEthashBlockRewardSchedule(m ctypes.Uint64BigMapEncodesHex) error {
 	return g.Config.SetEthashBlockRewardSchedule(m)
 }
 

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -21,7 +21,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -61,7 +61,7 @@ func (c *ChainConfig) SetAccountStartNonce(n *uint64) error {
 		return nil
 	}
 	if *n != 0 {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	return nil
 }
@@ -108,7 +108,7 @@ func (c *ChainConfig) GetNetworkID() *uint64 {
 
 func (c *ChainConfig) SetNetworkID(n *uint64) error {
 	if n == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.ChainID = new(big.Int).SetUint64(*n)
 	vars.DefaultNetworkID = *n
@@ -381,7 +381,7 @@ func (c *ChainConfig) SetForkCanonHash(n uint64, h common.Hash) error {
 		c.EIP150Hash = h
 		return nil
 	}
-	return common2.ErrUnsupportedConfigNoop
+	return ctypes.ErrUnsupportedConfigNoop
 }
 
 func (c *ChainConfig) GetForkCanonHashes() map[uint64]common.Hash {
@@ -393,26 +393,26 @@ func (c *ChainConfig) GetForkCanonHashes() map[uint64]common.Hash {
 	}
 }
 
-func (c *ChainConfig) GetConsensusEngineType() common2.ConsensusEngineT {
+func (c *ChainConfig) GetConsensusEngineType() ctypes.ConsensusEngineT {
 	if c.Ethash != nil {
-		return common2.ConsensusEngineT_Ethash
+		return ctypes.ConsensusEngineT_Ethash
 	}
 	if c.Clique != nil {
-		return common2.ConsensusEngineT_Clique
+		return ctypes.ConsensusEngineT_Clique
 	}
-	return common2.ConsensusEngineT_Unknown
+	return ctypes.ConsensusEngineT_Unknown
 }
 
-func (c *ChainConfig) MustSetConsensusEngineType(t common2.ConsensusEngineT) error {
+func (c *ChainConfig) MustSetConsensusEngineType(t ctypes.ConsensusEngineT) error {
 	switch t {
-	case common2.ConsensusEngineT_Ethash:
+	case ctypes.ConsensusEngineT_Ethash:
 		c.Ethash = new(EthashConfig)
 		return nil
-	case common2.ConsensusEngineT_Clique:
+	case ctypes.ConsensusEngineT_Clique:
 		c.Clique = new(CliqueConfig)
 		return nil
 	default:
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 }
 
@@ -422,7 +422,7 @@ func (c *ChainConfig) GetEthashMinimumDifficulty() *big.Int {
 
 func (c *ChainConfig) SetEthashMinimumDifficulty(i *big.Int) error {
 	if i == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	vars.MinimumDifficulty = i
 	return nil
@@ -434,7 +434,7 @@ func (c *ChainConfig) GetEthashDifficultyBoundDivisor() *big.Int {
 
 func (c *ChainConfig) SetEthashDifficultyBoundDivisor(i *big.Int) error {
 	if i == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	vars.DifficultyBoundDivisor = i
 	return nil
@@ -446,7 +446,7 @@ func (c *ChainConfig) GetEthashDurationLimit() *big.Int {
 
 func (c *ChainConfig) SetEthashDurationLimit(i *big.Int) error {
 	if i == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	vars.DurationLimit = i
 	return nil
@@ -484,7 +484,7 @@ func (c *ChainConfig) GetEthashEIP779Transition() *uint64 {
 
 func (c *ChainConfig) SetEthashEIP779Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.DAOForkBlock = setBig(c.DAOForkBlock, n)
 	if c.DAOForkBlock == nil {
@@ -499,7 +499,7 @@ func (c *ChainConfig) GetEthashEIP649Transition() *uint64 {
 
 func (c *ChainConfig) SetEthashEIP649Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.ByzantiumBlock = setBig(c.ByzantiumBlock, n)
 	return nil
@@ -511,7 +511,7 @@ func (c *ChainConfig) GetEthashEIP1234Transition() *uint64 {
 
 func (c *ChainConfig) SetEthashEIP1234Transition(n *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.ConstantinopleBlock = setBig(c.ConstantinopleBlock, n)
 	return nil
@@ -525,7 +525,7 @@ func (c *ChainConfig) SetEthashECIP1010PauseTransition(i *uint64) error {
 	if i == nil {
 		return nil
 	}
-	return common2.ErrUnsupportedConfigFatal
+	return ctypes.ErrUnsupportedConfigFatal
 }
 
 func (c *ChainConfig) GetEthashECIP1010ContinueTransition() *uint64 {
@@ -536,7 +536,7 @@ func (c *ChainConfig) SetEthashECIP1010ContinueTransition(i *uint64) error {
 	if i == nil {
 		return nil
 	}
-	return common2.ErrUnsupportedConfigFatal
+	return ctypes.ErrUnsupportedConfigFatal
 }
 
 func (c *ChainConfig) GetEthashECIP1017Transition() *uint64 {
@@ -547,7 +547,7 @@ func (c *ChainConfig) SetEthashECIP1017Transition(i *uint64) error {
 	if i == nil {
 		return nil
 	}
-	return common2.ErrUnsupportedConfigFatal
+	return ctypes.ErrUnsupportedConfigFatal
 }
 
 func (c *ChainConfig) GetEthashECIP1017EraRounds() *uint64 {
@@ -558,7 +558,7 @@ func (c *ChainConfig) SetEthashECIP1017EraRounds(i *uint64) error {
 	if i == nil {
 		return nil
 	}
-	return common2.ErrUnsupportedConfigFatal
+	return ctypes.ErrUnsupportedConfigFatal
 }
 
 func (c *ChainConfig) GetEthashEIP100BTransition() *uint64 {
@@ -567,7 +567,7 @@ func (c *ChainConfig) GetEthashEIP100BTransition() *uint64 {
 
 func (c *ChainConfig) SetEthashEIP100BTransition(i *uint64) error {
 	if c.Ethash == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.ByzantiumBlock = setBig(c.ByzantiumBlock, i)
 	return nil
@@ -581,23 +581,23 @@ func (c *ChainConfig) SetEthashECIP1041Transition(i *uint64) error {
 	if i == nil {
 		return nil
 	}
-	return common2.ErrUnsupportedConfigFatal
+	return ctypes.ErrUnsupportedConfigFatal
 }
 
-func (c *ChainConfig) GetEthashDifficultyBombDelaySchedule() common2.Uint64BigMapEncodesHex {
+func (c *ChainConfig) GetEthashDifficultyBombDelaySchedule() ctypes.Uint64BigMapEncodesHex {
 	return nil
 }
 
-func (c *ChainConfig) SetEthashDifficultyBombDelaySchedule(m common2.Uint64BigMapEncodesHex) error {
-	return common2.ErrUnsupportedConfigNoop
+func (c *ChainConfig) SetEthashDifficultyBombDelaySchedule(m ctypes.Uint64BigMapEncodesHex) error {
+	return ctypes.ErrUnsupportedConfigNoop
 }
 
-func (c *ChainConfig) GetEthashBlockRewardSchedule() common2.Uint64BigMapEncodesHex {
+func (c *ChainConfig) GetEthashBlockRewardSchedule() ctypes.Uint64BigMapEncodesHex {
 	return nil
 }
 
-func (c *ChainConfig) SetEthashBlockRewardSchedule(m common2.Uint64BigMapEncodesHex) error {
-	return common2.ErrUnsupportedConfigNoop
+func (c *ChainConfig) SetEthashBlockRewardSchedule(m ctypes.Uint64BigMapEncodesHex) error {
+	return ctypes.ErrUnsupportedConfigNoop
 }
 
 func (c *ChainConfig) GetCliquePeriod() uint64 {
@@ -609,7 +609,7 @@ func (c *ChainConfig) GetCliquePeriod() uint64 {
 
 func (c *ChainConfig) SetCliquePeriod(n uint64) error {
 	if c.Clique == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.Clique.Period = n
 	return nil
@@ -624,7 +624,7 @@ func (c *ChainConfig) GetCliqueEpoch() uint64 {
 
 func (c *ChainConfig) SetCliqueEpoch(n uint64) error {
 	if c.Clique == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	c.Clique.Epoch = n
 	return nil

--- a/params/types/parity/parity.go
+++ b/params/types/parity/parity.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 // ParityChainSpec is the chain specification format used by Parity.
@@ -40,13 +40,13 @@ type ParityChainSpec struct {
 				MinimumDifficulty      *math.HexOrDecimal256          `json:"minimumDifficulty"`
 				DifficultyBoundDivisor *math.HexOrDecimal256          `json:"difficultyBoundDivisor"`
 				DurationLimit          *math.HexOrDecimal256          `json:"durationLimit"`
-				BlockReward            common2.Uint64BigValOrMapHex   `json:"blockReward"`
-				DifficultyBombDelays   common2.Uint64BigMapEncodesHex `json:"difficultyBombDelays,omitempty"`
+				BlockReward            ctypes.Uint64BigValOrMapHex   `json:"blockReward"`
+				DifficultyBombDelays   ctypes.Uint64BigMapEncodesHex `json:"difficultyBombDelays,omitempty"`
 
 				// Caches.
 				// These inferences require computation.
 				// This makes it so that the 'heavy-lifting' only has to run once.
-				// See common2.ExtractHostageSituationN for this bespoke logic.
+				// See ctypes.ExtractHostageSituationN for this bespoke logic.
 				eip649inferred    bool       `json:"-"`
 				eip649Transition  *ParityU64 `json:"-"`
 				eip1234inferred   bool       `json:"-"`

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/vars"
 )
 
@@ -39,7 +39,7 @@ func (spec *ParityChainSpec) GetAccountStartNonce() *uint64 {
 
 func (spec *ParityChainSpec) SetAccountStartNonce(i *uint64) error {
 	if i == nil {
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 	spec.Params.AccountStartNonce = new(ParityU64).SetUint64(i)
 	return nil
@@ -473,24 +473,24 @@ func (spec *ParityChainSpec) GetForkCanonHashes() map[uint64]common.Hash {
 	}
 }
 
-func (spec *ParityChainSpec) GetConsensusEngineType() common2.ConsensusEngineT {
+func (spec *ParityChainSpec) GetConsensusEngineType() ctypes.ConsensusEngineT {
 	if !reflect.DeepEqual(spec.Engine.Ethash, reflect.Zero(reflect.TypeOf(spec.Engine.Ethash)).Interface()) {
-		return common2.ConsensusEngineT_Ethash
+		return ctypes.ConsensusEngineT_Ethash
 	}
 	if !reflect.DeepEqual(spec.Engine.Clique, reflect.Zero(reflect.TypeOf(spec.Engine.Clique)).Interface()) {
-		return common2.ConsensusEngineT_Clique
+		return ctypes.ConsensusEngineT_Clique
 	}
-	return common2.ConsensusEngineT_Unknown
+	return ctypes.ConsensusEngineT_Unknown
 }
 
-func (spec *ParityChainSpec) MustSetConsensusEngineType(t common2.ConsensusEngineT) error {
+func (spec *ParityChainSpec) MustSetConsensusEngineType(t ctypes.ConsensusEngineT) error {
 	switch t {
-	case common2.ConsensusEngineT_Ethash:
+	case ctypes.ConsensusEngineT_Ethash:
 		return nil
-	case common2.ConsensusEngineT_Clique:
+	case ctypes.ConsensusEngineT_Clique:
 		return nil
 	default:
-		return common2.ErrUnsupportedConfigFatal
+		return ctypes.ErrUnsupportedConfigFatal
 	}
 }
 
@@ -570,9 +570,9 @@ func (spec *ParityChainSpec) GetEthashEIP649Transition() *uint64 {
 		spec.Engine.Ethash.Params.eip649inferred = true
 	}()
 
-	diffN = common2.ExtractHostageSituationN(
+	diffN = ctypes.ExtractHostageSituationN(
 		spec.Engine.Ethash.Params.DifficultyBombDelays,
-		common2.Uint64BigMapEncodesHex(spec.Engine.Ethash.Params.BlockReward),
+		ctypes.Uint64BigMapEncodesHex(spec.Engine.Ethash.Params.BlockReward),
 		vars.EIP649DifficultyBombDelay,
 		vars.EIP649FBlockReward,
 	)
@@ -586,10 +586,10 @@ func (spec *ParityChainSpec) SetEthashEIP649Transition(n *uint64) error {
 		return nil
 	}
 	if spec.Engine.Ethash.Params.BlockReward == nil {
-		spec.Engine.Ethash.Params.BlockReward = common2.Uint64BigValOrMapHex{}
+		spec.Engine.Ethash.Params.BlockReward = ctypes.Uint64BigValOrMapHex{}
 	}
 	if spec.Engine.Ethash.Params.DifficultyBombDelays == nil {
-		spec.Engine.Ethash.Params.DifficultyBombDelays = common2.Uint64BigMapEncodesHex{}
+		spec.Engine.Ethash.Params.DifficultyBombDelays = ctypes.Uint64BigMapEncodesHex{}
 	}
 	spec.Engine.Ethash.Params.BlockReward[*n] = vars.EIP649FBlockReward
 
@@ -613,9 +613,9 @@ func (spec *ParityChainSpec) GetEthashEIP1234Transition() *uint64 {
 		spec.Engine.Ethash.Params.eip1234inferred = true
 	}()
 
-	diffN = common2.ExtractHostageSituationN(
+	diffN = ctypes.ExtractHostageSituationN(
 		spec.Engine.Ethash.Params.DifficultyBombDelays,
-		common2.Uint64BigMapEncodesHex(spec.Engine.Ethash.Params.BlockReward),
+		ctypes.Uint64BigMapEncodesHex(spec.Engine.Ethash.Params.BlockReward),
 		vars.EIP1234DifficultyBombDelay,
 		vars.EIP1234FBlockReward,
 	)
@@ -629,10 +629,10 @@ func (spec *ParityChainSpec) SetEthashEIP1234Transition(n *uint64) error {
 		return nil
 	}
 	if spec.Engine.Ethash.Params.BlockReward == nil {
-		spec.Engine.Ethash.Params.BlockReward = common2.Uint64BigValOrMapHex{}
+		spec.Engine.Ethash.Params.BlockReward = ctypes.Uint64BigValOrMapHex{}
 	}
 	if spec.Engine.Ethash.Params.DifficultyBombDelays == nil {
-		spec.Engine.Ethash.Params.DifficultyBombDelays = common2.Uint64BigMapEncodesHex{}
+		spec.Engine.Ethash.Params.DifficultyBombDelays = ctypes.Uint64BigMapEncodesHex{}
 	}
 	// Block reward is a simple lookup; doesn't matter if overwrite or not.
 	spec.Engine.Ethash.Params.BlockReward[*n] = vars.EIP1234FBlockReward
@@ -709,27 +709,27 @@ func (spec *ParityChainSpec) SetEthashECIP1041Transition(n *uint64) error {
 	return nil
 }
 
-func (spec *ParityChainSpec) GetEthashDifficultyBombDelaySchedule() common2.Uint64BigMapEncodesHex {
+func (spec *ParityChainSpec) GetEthashDifficultyBombDelaySchedule() ctypes.Uint64BigMapEncodesHex {
 	if reflect.DeepEqual(spec.Engine.Ethash, reflect.Zero(reflect.TypeOf(spec.Engine.Ethash)).Interface()) {
 		return nil
 	}
 	return spec.Engine.Ethash.Params.DifficultyBombDelays
 }
 
-func (spec *ParityChainSpec) SetEthashDifficultyBombDelaySchedule(input common2.Uint64BigMapEncodesHex) error {
+func (spec *ParityChainSpec) SetEthashDifficultyBombDelaySchedule(input ctypes.Uint64BigMapEncodesHex) error {
 	spec.Engine.Ethash.Params.DifficultyBombDelays = input
 	return nil
 }
 
-func (spec *ParityChainSpec) GetEthashBlockRewardSchedule() common2.Uint64BigMapEncodesHex {
+func (spec *ParityChainSpec) GetEthashBlockRewardSchedule() ctypes.Uint64BigMapEncodesHex {
 	if reflect.DeepEqual(spec.Engine.Ethash, reflect.Zero(reflect.TypeOf(spec.Engine.Ethash)).Interface()) {
 		return nil
 	}
-	return common2.Uint64BigMapEncodesHex(spec.Engine.Ethash.Params.BlockReward)
+	return ctypes.Uint64BigMapEncodesHex(spec.Engine.Ethash.Params.BlockReward)
 }
 
-func (spec *ParityChainSpec) SetEthashBlockRewardSchedule(input common2.Uint64BigMapEncodesHex) error {
-	spec.Engine.Ethash.Params.BlockReward = common2.Uint64BigValOrMapHex(input)
+func (spec *ParityChainSpec) SetEthashBlockRewardSchedule(input ctypes.Uint64BigMapEncodesHex) error {
+	spec.Engine.Ethash.Params.BlockReward = ctypes.Uint64BigValOrMapHex(input)
 	return nil
 }
 
@@ -759,23 +759,23 @@ func (spec *ParityChainSpec) SetCliqueEpoch(i uint64) error {
 	return nil
 }
 
-func (spec *ParityChainSpec) GetSealingType() common2.BlockSealingT {
+func (spec *ParityChainSpec) GetSealingType() ctypes.BlockSealingT {
 	if !reflect.DeepEqual(spec.Genesis.Seal.Ethereum, reflect.Zero(reflect.TypeOf(spec.Genesis.Seal.Ethereum)).Interface()) {
-		return common2.BlockSealing_Ethereum
+		return ctypes.BlockSealing_Ethereum
 	}
 	log.Println(spew.Sdump(spec.Genesis))
 	log.Println(spew.Sdump(reflect.Zero(reflect.TypeOf(spec.Genesis.Seal.Ethereum)).Interface()))
 	b, _ := json.MarshalIndent(spec, "", "    ")
 	log.Println(string(b))
-	return common2.BlockSealing_Unknown
+	return ctypes.BlockSealing_Unknown
 }
 
-func (spec *ParityChainSpec) SetSealingType(in common2.BlockSealingT) error {
+func (spec *ParityChainSpec) SetSealingType(in ctypes.BlockSealingT) error {
 	switch in {
-	case common2.BlockSealing_Ethereum:
+	case ctypes.BlockSealing_Ethereum:
 		return nil
 	}
-	return common2.ErrUnsupportedConfigFatal
+	return ctypes.ErrUnsupportedConfigFatal
 }
 
 func (spec *ParityChainSpec) GetGenesisSealerEthereumNonce() uint64 {

--- a/params/types/parity/parity_configurator_test.go
+++ b/params/types/parity/parity_configurator_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 // This file contains a few unit tests for the parity-specific configuration interface.
@@ -32,12 +32,12 @@ import (
 func TestParityChainSpec_GetConsensusEngineType(t *testing.T) {
 	spec := new(ParityChainSpec)
 
-	if engine := (*spec).GetConsensusEngineType(); engine != common.ConsensusEngineT_Unknown {
+	if engine := (*spec).GetConsensusEngineType(); engine != ctypes.ConsensusEngineT_Unknown {
 		t.Error("unwanted engine type", engine)
 	}
 
 	spec.Engine.Ethash.Params.MinimumDifficulty = math.NewHexOrDecimal256(42)
-	if engine := (*spec).GetConsensusEngineType(); engine != common.ConsensusEngineT_Ethash {
+	if engine := (*spec).GetConsensusEngineType(); engine != ctypes.ConsensusEngineT_Ethash {
 		t.Error("mismatch engine", engine)
 	}
 }

--- a/sanity/configurator_test.go
+++ b/sanity/configurator_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/convert"
 	paramtypes "github.com/ethereum/go-ethereum/params/types"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/parity"
 	"github.com/ethereum/go-ethereum/tests"
 	"github.com/go-test/deep"
@@ -38,12 +38,12 @@ import (
 
 func TestEquivalent_Features(t *testing.T) {
 
-	mustValidate := func (c common.ChainConfigurator) {
+	mustValidate := func (c ctypes.ChainConfigurator) {
 		zero, max := uint64(0), uint64(math.MaxUint64)
 		for _, head := range []*uint64{
 			nil, &zero, &max,
 		} {
-			if err := common.IsValid(c, head); err != nil {
+			if err := ctypes.IsValid(c, head); err != nil {
 				t.Fatalf("invalid config, err: %v", err)
 			}
 		}
@@ -54,7 +54,7 @@ func TestEquivalent_Features(t *testing.T) {
 		oconf := oconf
 
 		if oconf.GetConsensusEngineType().IsUnknown() {
-			oconf.MustSetConsensusEngineType(common.ConsensusEngineT_Ethash)
+			oconf.MustSetConsensusEngineType(ctypes.ConsensusEngineT_Ethash)
 		}
 
 		mustValidate(oconf)
@@ -73,7 +73,7 @@ func TestEquivalent_Features(t *testing.T) {
 			t.Fatal("unknown consensus mg")
 		}
 
-		err = common.Equivalent(oconf, mg)
+		err = ctypes.Equivalent(oconf, mg)
 		if err != nil {
 			t.Log("--------------------")
 			t.Errorf("%s oconf/mg err: %v", name, err)
@@ -111,7 +111,7 @@ func TestEquivalent_Features(t *testing.T) {
 
 		mustValidate(pc)
 
-		err = common.Equivalent(mg, pc)
+		err = ctypes.Equivalent(mg, pc)
 		if err != nil {
 			t.Errorf("%s oconf/p err: %v", name, err)
 		}
@@ -143,7 +143,7 @@ func TestEquivalent_ReadParity(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = common.Equivalent(a, b)
+		err = ctypes.Equivalent(a, b)
 		if err != nil {
 			t.Log("-------------------")
 			t.Log(b.Engine.Ethash.Params.BlockReward)

--- a/tests/block_test_util.go
+++ b/tests/block_test_util.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -143,7 +143,7 @@ func (t *BlockTest) Run() error {
 	return t.validateImportedHeaders(chain, validBlocks)
 }
 
-func (t *BlockTest) genesis(config common2.ChainConfigurator) *paramtypes.Genesis {
+func (t *BlockTest) genesis(config ctypes.ChainConfigurator) *paramtypes.Genesis {
 	if config == nil {
 		panic("nil block genesis config")
 	}

--- a/tests/difficulty_test_util.go
+++ b/tests/difficulty_test_util.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -48,7 +48,7 @@ var (
 	}
 )
 
-var difficultyChainConfigurations = map[string]common2.ChainConfigurator{
+var difficultyChainConfigurations = map[string]ctypes.ChainConfigurator{
 	"Ropsten":  params.TestnetChainConfig,
 	"Morden":   params.TestnetChainConfig,
 	"Frontier": &goethereum.ChainConfig{},
@@ -127,7 +127,7 @@ func (t *DifficultyTest) String() string {
 	return string(b)
 }
 
-func (test *DifficultyTest) Run(config common2.ChainConfigurator) error {
+func (test *DifficultyTest) Run(config ctypes.ChainConfigurator) error {
 	parentNumber := big.NewInt(int64(test.CurrentBlockNumber - 1))
 	parent := &types.Header{
 		Difficulty: test.ParentDifficulty,

--- a/tests/init.go
+++ b/tests/init.go
@@ -21,7 +21,7 @@ import (
 	"math/big"
 
 	paramtypes "github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/goethereum"
 )
 
@@ -30,7 +30,7 @@ func newUint64(n uint64) *uint64 {
 }
 
 // Forks table defines supported forks and their chain config.
-var Forks = map[string]common2.ChainConfigurator{
+var Forks = map[string]ctypes.ChainConfigurator{
 	"Frontier": &goethereum.ChainConfig{
 		Ethash:  new(goethereum.EthashConfig),
 		ChainID: big.NewInt(1),

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -33,7 +33,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/params/types"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 )
 
 // Command line flags to configure the interpreters.
@@ -112,7 +112,7 @@ type testMatcher struct {
 
 type testConfig struct {
 	p      *regexp.Regexp
-	config common.ChainConfigurator
+	config ctypes.ChainConfigurator
 }
 
 type testFailure struct {
@@ -143,7 +143,7 @@ func (tm *testMatcher) whitelist(pattern string) {
 }
 
 // config defines chain config for tests matching the pattern.
-func (tm *testMatcher) config(pattern string, cfg common.ChainConfigurator) {
+func (tm *testMatcher) config(pattern string, cfg ctypes.ChainConfigurator) {
 	tm.configpat = append(tm.configpat, testConfig{regexp.MustCompile(pattern), cfg})
 }
 
@@ -169,7 +169,7 @@ func (tm *testMatcher) findSkip(name string) (reason string, skipload bool) {
 }
 
 // findConfig returns the chain config matching defined patterns.
-func (tm *testMatcher) findConfig(name string) (common.ChainConfigurator, string) {
+func (tm *testMatcher) findConfig(name string) (ctypes.ChainConfigurator, string) {
 	// TODO(fjl): name can be derived from testing.T when min Go version is 1.8
 	for _, m := range tm.configpat {
 		if m.p.MatchString(name) {

--- a/tests/params.go
+++ b/tests/params.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/params/convert"
 	paramtypes "github.com/ethereum/go-ethereum/params/types"
-	"github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/params/types/parity"
 )
 
@@ -77,7 +77,7 @@ var mapForkNameChainspecFileDifficulty = map[string]string{
 	"ETC_Agharta":       "classic_agharta_difficulty_test.json",
 }
 
-func readConfigFromSpecFile(name string) (spec common.ChainConfigurator, sha1sum []byte, err error) {
+func readConfigFromSpecFile(name string) (spec ctypes.ChainConfigurator, sha1sum []byte, err error) {
 	spec = &parity.ParityChainSpec{}
 	if fi, err := os.Open(name); os.IsNotExist(err) {
 		return nil, nil, err
@@ -117,7 +117,7 @@ func init() {
 
 		for i, config := range Forks {
 			mgc := &paramtypes.MultiGethChainConfig{}
-			if err := convert.Convert(config, mgc); common.IsFatalUnsupportedErr(err) {
+			if err := convert.Convert(config, mgc); ctypes.IsFatalUnsupportedErr(err) {
 				panic(err)
 			}
 			Forks[i] = mgc
@@ -125,7 +125,7 @@ func init() {
 
 		for k, v := range difficultyChainConfigurations {
 			mgc := &paramtypes.MultiGethChainConfig{}
-			if err := convert.Convert(v, mgc); common.IsFatalUnsupportedErr(err) {
+			if err := convert.Convert(v, mgc); ctypes.IsFatalUnsupportedErr(err) {
 				panic(err)
 			}
 			difficultyChainConfigurations[k] = mgc
@@ -136,7 +136,7 @@ func init() {
 
 		for i, config := range Forks {
 			pspec := &parity.ParityChainSpec{}
-			if err := convert.Convert(config, pspec); common.IsFatalUnsupportedErr(err) {
+			if err := convert.Convert(config, pspec); ctypes.IsFatalUnsupportedErr(err) {
 				panic(err)
 			}
 			Forks[i] = pspec
@@ -144,7 +144,7 @@ func init() {
 
 		for k, v := range difficultyChainConfigurations {
 			pspec := &parity.ParityChainSpec{}
-			if err := convert.Convert(v, pspec); common.IsFatalUnsupportedErr(err) {
+			if err := convert.Convert(v, pspec); ctypes.IsFatalUnsupportedErr(err) {
 				panic(err)
 			}
 			difficultyChainConfigurations[k] = pspec

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -35,7 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
 )
@@ -140,7 +140,7 @@ type stTransactionMarshaling struct {
 // The fork definition can be
 // - a plain forkname, e.g. `Byzantium`,
 // - a fork basename, and a list of EIPs to enable; e.g. `Byzantium+1884+1283`.
-func getVMConfig(forkString string) (baseConfig common2.ChainConfigurator, eips []int, err error) {
+func getVMConfig(forkString string) (baseConfig ctypes.ChainConfigurator, eips []int, err error) {
 	var (
 		splitForks            = strings.Split(forkString, "+")
 		ok                    bool
@@ -247,7 +247,7 @@ func MakePreState(db ethdb.Database, accounts paramtypes.GenesisAlloc) *state.St
 	return statedb
 }
 
-func (t *StateTest) genesis(config common2.ChainConfigurator) *paramtypes.Genesis {
+func (t *StateTest) genesis(config ctypes.ChainConfigurator) *paramtypes.Genesis {
 	return &paramtypes.Genesis{
 		Config:     config,
 		Coinbase:   t.json.Env.Coinbase,

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
-	common2 "github.com/ethereum/go-ethereum/params/types/common"
+	"github.com/ethereum/go-ethereum/params/types/ctypes"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -44,7 +44,7 @@ type ttFork struct {
 	Hash   common.UnprefixedHash    `json:"hash"`
 }
 
-func (tt *TransactionTest) Run(config common2.ChainConfigurator) error {
+func (tt *TransactionTest) Run(config ctypes.ChainConfigurator) error {
 
 	validateTx := func(rlpData hexutil.Bytes, signer types.Signer, isEIP2F bool, isEIP2028F bool) (*common.Address, *common.Hash, error) {
 		tx := new(types.Transaction)


### PR DESCRIPTION
This avoids the ugly name-collision with common/ package name
which used common2. Now using ctypes.

Resolves https://github.com/etclabscore/multi-geth/pull/70#discussion_r355360173

Signed-off-by: meows <b5c6@protonmail.com>