### PR TITLE
cmd/utils: set networkid from config.gen

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1476,9 +1476,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
 	}
-	if ctx.GlobalIsSet(NetworkIdFlag.Name) {
-		cfg.NetworkId = ctx.GlobalUint64(NetworkIdFlag.Name)
-	}
+
 	if ctx.GlobalIsSet(CacheFlag.Name) || ctx.GlobalIsSet(CacheDatabaseFlag.Name) {
 		cfg.DatabaseCache = ctx.GlobalInt(CacheFlag.Name) * ctx.GlobalInt(CacheDatabaseFlag.Name) / 100
 	}
@@ -1526,6 +1524,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	// Override genesis configuration if a --<chain> flag.
 	if gen := genesisForCtxChainConfig(ctx); gen != nil {
 		cfg.Genesis = gen
+		cfg.NetworkId = gen.Config.NetworkID
 	}
 
 	if ctx.GlobalBool(DeveloperFlag.Name) {


### PR DESCRIPTION
This fixes an issue where chain flags like --mordor
were not causing network id values to be properly set.

Signed-off-by: meows <b5c6@protonmail.com>