### PR TITLE
core/vm,params/types: implement EIP1706

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -131,6 +131,11 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	// 	  2.2.2. If original value equals new value (this storage slot is reset)
 	//       2.2.2.1. If original value is 0, add 19800 gas to refund counter.
 	// 	     2.2.2.2. Otherwise, add 4800 gas to refund counter.
+
+	// Enforce sufficient gas left, per EIP1706, guarding against reentrancy attacks.
+	if contract.Gas <= vars.CallStipend && evm.chainConfig.IsForked(evm.chainConfig.GetEIP1706Transition, evm.BlockNumber) {
+		return 0, errGasLeftTooLow
+	}
 	value := common.BigToHash(y)
 	if current == value { // noop (1)
 		return vars.NetSstoreNoopGas, nil

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -32,6 +32,7 @@ type (
 )
 
 var errGasUintOverflow = errors.New("gas uint64 overflow")
+var errGasLeftTooLow = errors.New("insufficient gas left")
 
 type operation struct {
 	// execute is the operation function

--- a/params/types/ctypes/configurator_iface.go
+++ b/params/types/ctypes/configurator_iface.go
@@ -116,6 +116,8 @@ type CatHerder interface {
 	SetEIP2028Transition(n *uint64) error
 	GetECIP1080Transition() *uint64
 	SetECIP1080Transition(n *uint64) error
+	GetEIP1706Transition() *uint64
+	SetEIP1706Transition(n *uint64) error
 }
 
 type Forker interface {

--- a/params/types/genesisT/genesis.go
+++ b/params/types/genesisT/genesis.go
@@ -521,7 +521,7 @@ func (g *Genesis) SetECIP1080Transition(n *uint64) error {
 }
 
 func (g Genesis) GetEIP1706Transition() *uint64 {
-	return g.Config.GetECIP1080Transition()
+	return g.Config.GetEIP1706Transition()
 }
 
 func (g Genesis) SetEIP1706Transition(n *uint64) error {

--- a/params/types/genesisT/genesis.go
+++ b/params/types/genesisT/genesis.go
@@ -520,6 +520,14 @@ func (g *Genesis) SetECIP1080Transition(n *uint64) error {
 	return g.Config.SetECIP1080Transition(n)
 }
 
+func (g Genesis) GetEIP1706Transition() *uint64 {
+	return g.Config.GetECIP1080Transition()
+}
+
+func (g Genesis) SetEIP1706Transition(n *uint64) error {
+	return g.Config.SetEIP1706Transition(n)
+}
+
 func (g *Genesis) IsForked(fn func() *uint64, n *big.Int) bool {
 	return g.Config.IsForked(fn, n)
 }

--- a/params/types/goethereum/goethereum.go
+++ b/params/types/goethereum/goethereum.go
@@ -65,6 +65,9 @@ type ChainConfig struct {
 	// NOTE: These are not included in this type upstream.
 	TrustedCheckpoint       *ctypes.TrustedCheckpoint      `json:"trustedCheckpoint"`
 	TrustedCheckpointOracle *ctypes.CheckpointOracleConfig `json:"trustedCheckpointOracle"`
+
+	EIP1706Transition *big.Int `json:"-"`
+	ECIP1080Transition *big.Int `json:"-"`
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -359,6 +359,7 @@ func (c *ChainConfig) GetECIP1080Transition() *uint64 {
 
 func (c *ChainConfig) SetECIP1080Transition(n *uint64) error {
 	c.ECIP1080Transition = setBig(c.ECIP1080Transition, n)
+	return nil
 }
 
 func (c *ChainConfig) GetEIP1706Transition() *uint64 {

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -361,6 +361,14 @@ func (c *ChainConfig) SetECIP1080Transition(n *uint64) error {
 	return ctypes.ErrUnsupportedConfigFatal
 }
 
+func (c *ChainConfig) GetEIP1706Transition() *uint64 {
+	return nil
+}
+
+func (c *ChainConfig) SetEIP1706Transition(n *uint64) error {
+	return ctypes.ErrUnsupportedConfigFatal
+}
+
 func (c *ChainConfig) IsForked(fn func() *uint64, n *big.Int) bool {
 	f := fn()
 	if f == nil || n == nil {

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -354,19 +354,20 @@ func (c *ChainConfig) SetEIP2028Transition(n *uint64) error {
 }
 
 func (c *ChainConfig) GetECIP1080Transition() *uint64 {
-	return nil
+	return bigNewU64(c.ECIP1080Transition) // FIXME, fudgey
 }
 
 func (c *ChainConfig) SetECIP1080Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.ECIP1080Transition = setBig(c.ECIP1080Transition, n)
 }
 
 func (c *ChainConfig) GetEIP1706Transition() *uint64 {
-	return nil
+	return bigNewU64(c.EIP1706Transition)
 }
 
 func (c *ChainConfig) SetEIP1706Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.EIP1706Transition = setBig(c.EIP1706Transition, n)
+	return nil
 }
 
 func (c *ChainConfig) IsForked(fn func() *uint64, n *big.Int) bool {

--- a/params/types/multigeth/chain_config.go
+++ b/params/types/multigeth/chain_config.go
@@ -157,6 +157,10 @@ type MultiGethChainConfig struct {
 	eip2384Inferred bool
 	EIP2384FBlock   *big.Int `json:"eip2384FBlock,omitempty"`
 
+	// EIP-1706: Resolves reentrancy attack vector enabled with EIP1283.
+	// https://eips.ethereum.org/EIPS/eip-1706
+	EIP1706FBlock *big.Int `json:"eip1706FBlock,omitempty"`
+
 	//EWASMBlock *big.Int `json:"ewasmBlock,omitempty"` // EWASM switch block (nil = no fork, 0 = already activated)
 
 	ECIP1010PauseBlock *big.Int `json:"ecip1010PauseBlock,omitempty"` // ECIP1010 pause HF block

--- a/params/types/multigeth/chain_config_configurator.go
+++ b/params/types/multigeth/chain_config_configurator.go
@@ -354,6 +354,15 @@ func (c *MultiGethChainConfig) SetECIP1080Transition(n *uint64) error {
 	return nil
 }
 
+func (c *MultiGethChainConfig) GetEIP1706Transition() *uint64 {
+	return bigNewU64(c.EIP1706FBlock)
+}
+
+func (c *MultiGethChainConfig) SetEIP1706Transition(n *uint64) error {
+	c.EIP1706FBlock = setBig(c.EIP1706FBlock, n)
+	return nil
+}
+
 func (c *MultiGethChainConfig) IsForked(fn func() *uint64, n *big.Int) bool {
 	f := fn()
 	if f == nil || n == nil {

--- a/params/types/parity/parity.go
+++ b/params/types/parity/parity.go
@@ -106,6 +106,7 @@ type ParityChainSpec struct {
 		EIP1344Transition         *ParityU64 `json:"eip1344Transition,omitempty"`
 		EIP1884Transition         *ParityU64 `json:"eip1884Transition,omitempty"`
 		EIP2028Transition         *ParityU64 `json:"eip2028Transition,omitempty"`
+		EIP1706Transition         *ParityU64 `json:"eip1706Transition,omitempty"`
 
 		ForkBlock     *ParityU64   `json:"forkBlock,omitempty"`
 		ForkCanonHash *common.Hash `json:"forkCanonHash,omitempty"`

--- a/params/types/parity/parity.go
+++ b/params/types/parity/parity.go
@@ -106,7 +106,8 @@ type ParityChainSpec struct {
 		EIP1344Transition         *ParityU64 `json:"eip1344Transition,omitempty"`
 		EIP1884Transition         *ParityU64 `json:"eip1884Transition,omitempty"`
 		EIP2028Transition         *ParityU64 `json:"eip2028Transition,omitempty"`
-		EIP1706Transition         *ParityU64 `json:"eip1706Transition,omitempty"`
+		EIP1706Transition         *ParityU64 `json:"-"` // FIXME, when and if i'm implemented in Parity
+		ECIP1080Transition        *ParityU64 `json:"-"` // FIXME, when and if i'm implemented in Parity
 
 		ForkBlock     *ParityU64   `json:"forkBlock,omitempty"`
 		ForkCanonHash *common.Hash `json:"forkCanonHash,omitempty"`

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -449,11 +449,12 @@ func (spec *ParityChainSpec) SetEIP1108Transition(n *uint64) error {
 }
 
 func (c *ParityChainSpec) GetECIP1080Transition() *uint64 {
-	return nil // FIXME when+if upstream implements
+	return c.Params.ECIP1080Transition.Uint64P()
 }
 
 func (c *ParityChainSpec) SetECIP1080Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.Params.ECIP1080Transition = new(ParityU64).SetUint64(n)
+	return nil
 }
 
 func (c *ParityChainSpec) GetEIP1706Transition() *uint64 {

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -457,11 +457,12 @@ func (c *ParityChainSpec) SetECIP1080Transition(n *uint64) error {
 }
 
 func (c *ParityChainSpec) GetEIP1706Transition() *uint64 {
-	return nil // FIXME when+if upstream implements
+	return c.Params.EIP1706Transition.Uint64P() // FIXME when+if upstream implements
 }
 
 func (c *ParityChainSpec) SetEIP1706Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.Params.EIP1706Transition = new(ParityU64).SetUint64(i)
+	return nil
 }
 
 func (spec *ParityChainSpec) IsForked(fn func() *uint64, n *big.Int) bool {

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -462,7 +462,7 @@ func (c *ParityChainSpec) GetEIP1706Transition() *uint64 {
 }
 
 func (c *ParityChainSpec) SetEIP1706Transition(n *uint64) error {
-	c.Params.EIP1706Transition = new(ParityU64).SetUint64(i)
+	c.Params.EIP1706Transition = new(ParityU64).SetUint64(n)
 	return nil
 }
 

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -456,6 +456,14 @@ func (c *ParityChainSpec) SetECIP1080Transition(n *uint64) error {
 	return ctypes.ErrUnsupportedConfigFatal
 }
 
+func (c *ParityChainSpec) GetEIP1706Transition() *uint64 {
+	return nil // FIXME when+if upstream implements
+}
+
+func (c *ParityChainSpec) SetEIP1706Transition(n *uint64) error {
+	return ctypes.ErrUnsupportedConfigFatal
+}
+
 func (spec *ParityChainSpec) IsForked(fn func() *uint64, n *big.Int) bool {
 	f := fn()
 	if f == nil || n == nil {


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-1706

Implements EIP1706, intended to guard against reentrancy
attack vector enabled with EIP1283.

Enforce that a contract using SSTORE opcode has > CallStipend
(2300) gas available.

Signed-off-by: meows <b5c6@protonmail.com>

---

_Reviewer note_: This PR has #125 as base ref.