### PR TITLE
Feat/1706 1080 parity goethereum impls

### DIFF
--- a/params/types/goethereum/goethereum.go
+++ b/params/types/goethereum/goethereum.go
@@ -65,6 +65,9 @@ type ChainConfig struct {
 	// NOTE: These are not included in this type upstream.
 	TrustedCheckpoint       *ctypes.TrustedCheckpoint      `json:"trustedCheckpoint"`
 	TrustedCheckpointOracle *ctypes.CheckpointOracleConfig `json:"trustedCheckpointOracle"`
+
+	EIP1706Transition *big.Int `json:"-"`
+	ECIP1080Transition *big.Int `json:"-"`
 }
 
 // String implements the fmt.Stringer interface.

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -359,6 +359,7 @@ func (c *ChainConfig) GetECIP1080Transition() *uint64 {
 
 func (c *ChainConfig) SetECIP1080Transition(n *uint64) error {
 	c.ECIP1080Transition = setBig(c.ECIP1080Transition, n)
+	return nil
 }
 
 func (c *ChainConfig) GetEIP1706Transition() *uint64 {

--- a/params/types/goethereum/goethereum_configurator.go
+++ b/params/types/goethereum/goethereum_configurator.go
@@ -354,19 +354,20 @@ func (c *ChainConfig) SetEIP2028Transition(n *uint64) error {
 }
 
 func (c *ChainConfig) GetECIP1080Transition() *uint64 {
-	return nil
+	return bigNewU64(c.ECIP1080Transition) // FIXME, fudgey
 }
 
 func (c *ChainConfig) SetECIP1080Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.ECIP1080Transition = setBig(c.ECIP1080Transition, n)
 }
 
 func (c *ChainConfig) GetEIP1706Transition() *uint64 {
-	return nil
+	return bigNewU64(c.EIP1706Transition)
 }
 
 func (c *ChainConfig) SetEIP1706Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.EIP1706Transition = setBig(c.EIP1706Transition, n)
+	return nil
 }
 
 func (c *ChainConfig) IsForked(fn func() *uint64, n *big.Int) bool {

--- a/params/types/parity/parity.go
+++ b/params/types/parity/parity.go
@@ -106,6 +106,7 @@ type ParityChainSpec struct {
 		EIP1344Transition         *ParityU64 `json:"eip1344Transition,omitempty"`
 		EIP1884Transition         *ParityU64 `json:"eip1884Transition,omitempty"`
 		EIP2028Transition         *ParityU64 `json:"eip2028Transition,omitempty"`
+		EIP1706Transition         *ParityU64 `json:"eip1706Transition,omitempty"`
 
 		ForkBlock     *ParityU64   `json:"forkBlock,omitempty"`
 		ForkCanonHash *common.Hash `json:"forkCanonHash,omitempty"`

--- a/params/types/parity/parity.go
+++ b/params/types/parity/parity.go
@@ -106,7 +106,8 @@ type ParityChainSpec struct {
 		EIP1344Transition         *ParityU64 `json:"eip1344Transition,omitempty"`
 		EIP1884Transition         *ParityU64 `json:"eip1884Transition,omitempty"`
 		EIP2028Transition         *ParityU64 `json:"eip2028Transition,omitempty"`
-		EIP1706Transition         *ParityU64 `json:"eip1706Transition,omitempty"`
+		EIP1706Transition         *ParityU64 `json:"-"` // FIXME, when and if i'm implemented in Parity
+		ECIP1080Transition        *ParityU64 `json:"-"` // FIXME, when and if i'm implemented in Parity
 
 		ForkBlock     *ParityU64   `json:"forkBlock,omitempty"`
 		ForkCanonHash *common.Hash `json:"forkCanonHash,omitempty"`

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -449,11 +449,12 @@ func (spec *ParityChainSpec) SetEIP1108Transition(n *uint64) error {
 }
 
 func (c *ParityChainSpec) GetECIP1080Transition() *uint64 {
-	return nil // FIXME when+if upstream implements
+	return c.Params.ECIP1080Transition.Uint64P()
 }
 
 func (c *ParityChainSpec) SetECIP1080Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.Params.ECIP1080Transition = new(ParityU64).SetUint64(n)
+	return nil
 }
 
 func (c *ParityChainSpec) GetEIP1706Transition() *uint64 {

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -457,11 +457,12 @@ func (c *ParityChainSpec) SetECIP1080Transition(n *uint64) error {
 }
 
 func (c *ParityChainSpec) GetEIP1706Transition() *uint64 {
-	return nil // FIXME when+if upstream implements
+	return c.Params.EIP1706Transition.Uint64P() // FIXME when+if upstream implements
 }
 
 func (c *ParityChainSpec) SetEIP1706Transition(n *uint64) error {
-	return ctypes.ErrUnsupportedConfigFatal
+	c.Params.EIP1706Transition = new(ParityU64).SetUint64(i)
+	return nil
 }
 
 func (spec *ParityChainSpec) IsForked(fn func() *uint64, n *big.Int) bool {

--- a/params/types/parity/parity_configurator.go
+++ b/params/types/parity/parity_configurator.go
@@ -462,7 +462,7 @@ func (c *ParityChainSpec) GetEIP1706Transition() *uint64 {
 }
 
 func (c *ParityChainSpec) SetEIP1706Transition(n *uint64) error {
-	c.Params.EIP1706Transition = new(ParityU64).SetUint64(i)
+	c.Params.EIP1706Transition = new(ParityU64).SetUint64(n)
 	return nil
 }
 


### PR DESCRIPTION
Adds adhoc support to goethereum and parity data types, using not-exported-to-json fields. Isn't the prettiest thing in the world. But might help the tests pass without causing too many other side effects.