### PR TITLE
core/vm,params/vars: "correctly" implement EIP2200 SLOAD gas cost change

### DIFF
--- a/core/vm/eips.go
+++ b/core/vm/eips.go
@@ -56,9 +56,9 @@ func enableSelfBalance(jt *JumpTable) {
 // - Define SELFBALANCE, with cost GasFastStep (5)
 func enable1884(jt *JumpTable) {
 	// Gas cost changes
+	jt[SLOAD].constantGas = vars.SloadGasEIP1884
 	jt[BALANCE].constantGas = vars.BalanceGasEIP1884
 	jt[EXTCODEHASH].constantGas = vars.ExtcodeHashGasEIP1884
-	jt[SLOAD].constantGas = vars.SloadGasEIP1884
 
 	// New opcode
 	enableSelfBalance(jt)
@@ -92,5 +92,6 @@ func opChainID(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memo
 
 // enable2200 applies EIP-2200 (Rebalance net-metered SSTORE)
 func enable2200(jt *JumpTable) {
+	jt[SLOAD].constantGas = vars.SloadGasEIP2200
 	jt[SSTORE].dynamicGas = gasSStoreEIP2200
 }

--- a/params/vars/protocol_params.go
+++ b/params/vars/protocol_params.go
@@ -104,6 +104,7 @@ var (
 	SloadGasFrontier             uint64 = 50
 	SloadGasEIP150               uint64 = 200
 	SloadGasEIP1884              uint64 = 800  // Cost of SLOAD after EIP 1884 (part of Istanbul)
+	SloadGasEIP2200              uint64 = 800  // Cost of SLOAD after EIP 2200 (part of Istanbul)
 	ExtcodeHashGasConstantinople uint64 = 400  // Cost of EXTCODEHASH (introduced in Constantinople)
 	ExtcodeHashGasEIP1884        uint64 = 700  // Cost of EXTCODEHASH after EIP 1884 (part in Istanbul)
 	SelfdestructGasEIP150        uint64 = 5000 // Cost of SELFDESTRUCT post EIP 150 (Tangerine)


### PR DESCRIPTION
- https://eips.ethereum.org/EIPS/eip-2200
- https://eips.ethereum.org/EIPS/eip-1884

EIP2200 is implemented simultaneously with 1884
on the ETH nets, rendering this somewhat redundant.
But other networks may care, and this changeset
should be handled carefully, since either or both
2200 1884 may be live with or without the other.

Signed-off-by: meows <b5c6@protonmail.com>

---

- https://twitter.com/gregthegreek/status/1226957365783777280?s=19
- Rel https://github.com/ethereum/go-ethereum/pull/20646