### PR TITLE
feat: implement ETC networks configs ECIP1078

### DIFF
--- a/params/config_classic.go
+++ b/params/config_classic.go
@@ -54,21 +54,25 @@ var (
 		EIP214FBlock: big.NewInt(8772000),
 		EIP658FBlock: big.NewInt(8772000),
 
-		// Constantinople eq
+		// Constantinople eq, aka Agharta
 		EIP145FBlock:  big.NewInt(9573000),
 		EIP1014FBlock: big.NewInt(9573000),
 		EIP1052FBlock: big.NewInt(9573000),
 
-		// Istanbul eq
-		EIP152FBlock:  big.NewInt(10500839),
-		EIP1108FBlock: big.NewInt(10500839),
-		EIP1344FBlock: big.NewInt(10500839),
+		// Istanbul eq, aka Aztlan
+		// ECIP-1061
+		EIP152FBlock:  big.NewInt(10_500_839),
+		EIP1108FBlock: big.NewInt(10_500_839),
+		EIP1344FBlock: big.NewInt(10_500_839),
 		EIP1884FBlock: nil,
-		EIP2028FBlock: big.NewInt(10500839),
-		EIP2200FBlock: big.NewInt(10500839), // RePetersburg (=~ re-1283)
+		EIP2028FBlock: big.NewInt(10_500_839),
+		EIP2200FBlock: big.NewInt(10_500_839), // RePetersburg (=~ re-1283)
 
-		EIP1283FBlock:   nil,
-		PetersburgBlock: nil, // Un1283
+		// ECIP-1078, aka Phoenix Fix
+		EIP2200DisableFBlock: big.NewInt(10_500_839),
+		EIP1283FBlock:        big.NewInt(10_500_839),
+		EIP1706FBlock:        big.NewInt(10_500_839),
+		ECIP1080FBlock:       big.NewInt(10_500_839),
 
 		DisposalBlock:      big.NewInt(5900000),
 		ECIP1017FBlock:     big.NewInt(5000000),

--- a/params/config_kotti.go
+++ b/params/config_kotti.go
@@ -57,18 +57,25 @@ var (
 		EIP214FBlock: big.NewInt(716617),
 		EIP658FBlock: big.NewInt(716617),
 
-		// Constantinople eq
+		// Constantinople eq, aka Agharta
 		EIP145FBlock:  big.NewInt(1705549),
 		EIP1014FBlock: big.NewInt(1705549),
 		EIP1052FBlock: big.NewInt(1705549),
 
-		// Istanbul eq
+		// Istanbul eq, aka Aztlan
+		// ECIP-1061
 		EIP152FBlock:  big.NewInt(2058191),
 		EIP1108FBlock: big.NewInt(2058191),
 		EIP1344FBlock: big.NewInt(2058191),
 		EIP1884FBlock: nil,
 		EIP2028FBlock: big.NewInt(2058191),
 		EIP2200FBlock: big.NewInt(2058191), // RePetersburg (== re-1283)
+
+		// ECIP-1078, aka Phoenix Fix
+		EIP2200DisableFBlock: big.NewInt(2_208_203),
+		EIP1283FBlock:        big.NewInt(2_208_203),
+		EIP1706FBlock:        big.NewInt(2_208_203),
+		ECIP1080FBlock:       big.NewInt(2_208_203),
 
 		ECIP1017FBlock:    big.NewInt(5000000),
 		ECIP1017EraRounds: big.NewInt(5000000),

--- a/params/config_mordor.go
+++ b/params/config_mordor.go
@@ -51,18 +51,25 @@ var (
 		EIP214FBlock: big.NewInt(0),
 		EIP658FBlock: big.NewInt(0),
 
-		// Constantinople eq
+		// Constantinople eq, aka Agharta
 		EIP145FBlock:  big.NewInt(301243),
 		EIP1014FBlock: big.NewInt(301243),
 		EIP1052FBlock: big.NewInt(301243),
 
-		// Istanbul eq
+		// Istanbul eq, aka Aztlan
+		// ECIP-1061
 		EIP152FBlock:  big.NewInt(778507),
 		EIP1108FBlock: big.NewInt(778507),
 		EIP1344FBlock: big.NewInt(778507),
 		EIP1884FBlock: nil,
 		EIP2028FBlock: big.NewInt(778507),
 		EIP2200FBlock: big.NewInt(778507), // RePetersburg (== re-1283)
+
+		// ECIP-1078, aka Phoenix Fix
+		EIP2200DisableFBlock: big.NewInt(976_231),
+		EIP1283FBlock:        big.NewInt(976_231),
+		EIP1706FBlock:        big.NewInt(976_231),
+		ECIP1080FBlock:       big.NewInt(976_231),
 
 		DisposalBlock:      big.NewInt(0),
 		ECIP1017FBlock:     big.NewInt(0),


### PR DESCRIPTION
This reverts commit f9c254e4e6abc91f963ee39a626ca6caafeacc82, with the effect and intention of only essentially re-opening #128.

---

The story goes:
- branch with +ECIP1078 changes (https://github.com/etclabscore/multi-geth/pull/128)
- next branch for refactoring built, dumbly, on top of that one, https://github.com/etclabscore/multi-geth/pull/140
    + this branch realizes that it was dumb to include 1078, flatly reverts config file changes (https://github.com/etclabscore/multi-geth/pull/140/commits/f9c254e4e6abc91f963ee39a626ca6caafeacc82)
    + gets merged

...so ECIP1078 was introduced to `master` and removed with same PR (and #128 unintentionally closed).

This PR undoes the disabled ECIP1078, effectively proposing to enable it. Maybe even for real this time.
