### PR TITLE
params: rename client to CoreGeth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       provider: releases
       api_key:
         secure: pGlbI2DRfTzdF75hkEwP5vMIpcP1iVEeW3W41DT1X+/GQPlgDN1DB/ocXtMbEId2vJCWgt1HfCSNb9F4NBI94TMamFJQPz4zy/VIXBClG1IGesloe159vU4PixrLBgeTTcuDJRx7X45JeKlHW9LN5ABxeEhYEzPj1De6P5NDePmbFNDvhOkaf5Spk0xGLumRzzf2SHk+w3au9RQM5gVUcgr5U81Qi/ys8aGCLtZ1T+avSoX9rFoB1/YGoHllJfMoNGJr5CLiBwnFGMY8SNfD7XruFptUjTe4D0sMNTgAbT8iDPbw9s5aa2ou2eFWsuGaa8v840kLF+J0dEW0L/y88YzzRbbK3Ve6qNvka8MZ26HLSry7JtAqT6QY0W+h2yMgOmJX6ehlCGg1PoZYVwTp4d0usE88CGa8kTSNlt6/OxVmvNU5E2TPCbiTxF1yI42RliE+r7FyX5TtvXvZmSzfrlZcJFn3amC02woe1Fs0GJWvscxdqyftuyIezpaRmkIrL0X+OzYjOLJA2CH6eUdJu0O52zSLg00UeXDd4y9dBgm8AWD1k5tuHQrqq2/tF7abz2XOtmt3cuL9XYOcbXm0lf88AiOEusDaWCoPNNBmvL8mJMCwLWdNsRGQO6NhdkzqH81njP86TCdpFQi7OJDgTobEuy+NXwRkx4B0620JssU=
-      file: multi-geth*-$TRAVIS_OS_NAME.*
+      file: core-geth*-$TRAVIS_OS_NAME.*
       file_glob: true
       draft: true
       on:
@@ -47,7 +47,7 @@ matrix:
       provider: releases
       api_key:
         secure: pGlbI2DRfTzdF75hkEwP5vMIpcP1iVEeW3W41DT1X+/GQPlgDN1DB/ocXtMbEId2vJCWgt1HfCSNb9F4NBI94TMamFJQPz4zy/VIXBClG1IGesloe159vU4PixrLBgeTTcuDJRx7X45JeKlHW9LN5ABxeEhYEzPj1De6P5NDePmbFNDvhOkaf5Spk0xGLumRzzf2SHk+w3au9RQM5gVUcgr5U81Qi/ys8aGCLtZ1T+avSoX9rFoB1/YGoHllJfMoNGJr5CLiBwnFGMY8SNfD7XruFptUjTe4D0sMNTgAbT8iDPbw9s5aa2ou2eFWsuGaa8v840kLF+J0dEW0L/y88YzzRbbK3Ve6qNvka8MZ26HLSry7JtAqT6QY0W+h2yMgOmJX6ehlCGg1PoZYVwTp4d0usE88CGa8kTSNlt6/OxVmvNU5E2TPCbiTxF1yI42RliE+r7FyX5TtvXvZmSzfrlZcJFn3amC02woe1Fs0GJWvscxdqyftuyIezpaRmkIrL0X+OzYjOLJA2CH6eUdJu0O52zSLg00UeXDd4y9dBgm8AWD1k5tuHQrqq2/tF7abz2XOtmt3cuL9XYOcbXm0lf88AiOEusDaWCoPNNBmvL8mJMCwLWdNsRGQO6NhdkzqH81njP86TCdpFQi7OJDgTobEuy+NXwRkx4B0620JssU=
-      file: multi-geth*-arm.*
+      file: core-geth*-arm.*
       file_glob: true
       draft: true
       on:
@@ -74,7 +74,7 @@ matrix:
       provider: releases
       api_key:
         secure: pGlbI2DRfTzdF75hkEwP5vMIpcP1iVEeW3W41DT1X+/GQPlgDN1DB/ocXtMbEId2vJCWgt1HfCSNb9F4NBI94TMamFJQPz4zy/VIXBClG1IGesloe159vU4PixrLBgeTTcuDJRx7X45JeKlHW9LN5ABxeEhYEzPj1De6P5NDePmbFNDvhOkaf5Spk0xGLumRzzf2SHk+w3au9RQM5gVUcgr5U81Qi/ys8aGCLtZ1T+avSoX9rFoB1/YGoHllJfMoNGJr5CLiBwnFGMY8SNfD7XruFptUjTe4D0sMNTgAbT8iDPbw9s5aa2ou2eFWsuGaa8v840kLF+J0dEW0L/y88YzzRbbK3Ve6qNvka8MZ26HLSry7JtAqT6QY0W+h2yMgOmJX6ehlCGg1PoZYVwTp4d0usE88CGa8kTSNlt6/OxVmvNU5E2TPCbiTxF1yI42RliE+r7FyX5TtvXvZmSzfrlZcJFn3amC02woe1Fs0GJWvscxdqyftuyIezpaRmkIrL0X+OzYjOLJA2CH6eUdJu0O52zSLg00UeXDd4y9dBgm8AWD1k5tuHQrqq2/tF7abz2XOtmt3cuL9XYOcbXm0lf88AiOEusDaWCoPNNBmvL8mJMCwLWdNsRGQO6NhdkzqH81njP86TCdpFQi7OJDgTobEuy+NXwRkx4B0620JssU=
-      file: multi-geth*-$TRAVIS_OS_NAME.*
+      file: core-geth*-$TRAVIS_OS_NAME.*
       file_glob: true
       draft: true
       on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,12 @@ install:
 
 build_script:
   - go run build\ci.go install
-  - 7z a multi-geth-win64.zip .\build\bin\geth.exe
-  - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256
-  - ps: Get-FileHash multi-geth-win64.zip -Algorithm SHA256 | Out-File multi-geth-win64.zip.sha256
-  - 7z a multi-geth-alltools-win64.zip .\build\bin\*
-  - ps: Get-FileHash multi-geth-alltools-win64.zip -Algorithm SHA256
-  - ps: Get-FileHash multi-geth-alltools-win64.zip | Out-File multi-geth-alltools-win64.zip.sha256
+  - 7z a core-geth-win64.zip .\build\bin\geth.exe
+  - ps: Get-FileHash core-geth-win64.zip -Algorithm SHA256
+  - ps: Get-FileHash core-geth-win64.zip -Algorithm SHA256 | Out-File core-geth-win64.zip.sha256
+  - 7z a core-geth-alltools-win64.zip .\build\bin\*
+  - ps: Get-FileHash core-geth-alltools-win64.zip -Algorithm SHA256
+  - ps: Get-FileHash core-geth-alltools-win64.zip | Out-File core-geth-alltools-win64.zip.sha256
 
 for:
   - branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,15 +32,22 @@ build_script:
   - ps: Get-FileHash multi-geth-alltools-win64.zip -Algorithm SHA256
   - ps: Get-FileHash multi-geth-alltools-win64.zip | Out-File multi-geth-alltools-win64.zip.sha256
 
-artifacts:
-  - path: '*core-geth*.zip'
-    name: geth
-  - path: '*core-geth*.zip.sha256'
-    name: geth-sha256
-  - path: '*core-geth-alltools*.zip'
-    name: alltools
-  - path: '*core-geth-alltools*.zip.sha256'
-    name: alltools-sha256
+for:
+  - branches:
+      only:
+        - master
+        - /v\d*\.\d*\.\d*/
+        - /v\d*\.\d*\.\d*-beta\.\d*/
+        - release*
+    artifacts:
+      - path: '*core-geth*.zip'
+        name: geth
+      - path: '*core-geth*.zip.sha256'
+        name: geth-sha256
+      - path: '*core-geth-alltools*.zip'
+        name: alltools
+      - path: '*core-geth-alltools*.zip.sha256'
+        name: alltools-sha256
 
 deploy:
   provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,19 +33,19 @@ build_script:
   - ps: Get-FileHash multi-geth-alltools-win64.zip | Out-File multi-geth-alltools-win64.zip.sha256
 
 artifacts:
-  - path: '*multi-geth*.zip'
+  - path: '*core-geth*.zip'
     name: geth
-  - path: '*multi-geth*.zip.sha256'
+  - path: '*core-geth*.zip.sha256'
     name: geth-sha256
-  - path: '*multi-geth-alltools*.zip'
+  - path: '*core-geth-alltools*.zip'
     name: alltools
-  - path: '*multi-geth-alltools*.zip.sha256'
+  - path: '*core-geth-alltools*.zip.sha256'
     name: alltools-sha256
 
 deploy:
   provider: GitHub
   repository: etclabscore/multi-geth
-  artifact: /multi-geth.*-win64\.zip.*/
+  artifact: /core-geth.*-win64\.zip.*/
   auth_token:
     secure: 2ImMvNMj+kevxYhBcAzbqII4cGC/SIX1Kvp0yDwIOBveSr7n8FhX84o+XzOkY3cI
   draft: true

--- a/build/deploy.sh
+++ b/build/deploy.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-GETH_ARCHIVE_NAME="multi-geth-$TRAVIS_OS_NAME"
+GETH_ARCHIVE_NAME="core-geth-$TRAVIS_OS_NAME"
 zip -j "$GETH_ARCHIVE_NAME.zip" build/bin/geth
 
 shasum -a 256 $GETH_ARCHIVE_NAME.zip
 shasum -a 256 $GETH_ARCHIVE_NAME.zip > $GETH_ARCHIVE_NAME.zip.sha256
 
-ALLTOOLS_ARCHIVE_NAME="multi-geth-alltools-$TRAVIS_OS_NAME"
+ALLTOOLS_ARCHIVE_NAME="core-geth-alltools-$TRAVIS_OS_NAME"
 zip -j "$ALLTOOLS_ARCHIVE_NAME.zip" build/bin/*
 
 shasum -a 256 $ALLTOOLS_ARCHIVE_NAME.zip

--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -97,7 +97,7 @@ func loadConfig(file string, cfg *gethConfig) error {
 
 func defaultNodeConfig() node.Config {
 	cfg := node.DefaultConfig
-	cfg.Name = clientIdentifier
+	cfg.Name = databaseIdentifier
 	cfg.Version = params.VersionWithCommit(gitCommit, gitDate)
 	cfg.HTTPModules = append(cfg.HTTPModules, "eth", "shh")
 	cfg.WSModules = append(cfg.WSModules, "eth", "shh")

--- a/cmd/geth/consolecmd.go
+++ b/cmd/geth/consolecmd.go
@@ -177,7 +177,7 @@ func remoteConsole(ctx *cli.Context) error {
 // for "geth attach" and "geth monitor" with no argument.
 func dialRPC(endpoint string) (*rpc.Client, error) {
 	if endpoint == "" {
-		endpoint = node.DefaultIPCEndpoint(clientIdentifier)
+		endpoint = node.DefaultIPCEndpoint(databaseIdentifier)
 	} else if strings.HasPrefix(endpoint, "rpc:") || strings.HasPrefix(endpoint, "ipc:") {
 		// Backwards compatibility with geth < 1.5 which required
 		// these prefixes.

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -49,6 +49,7 @@ import (
 
 const (
 	clientIdentifier = "core" // Client identifier to advertise over the network
+	databaseIdentifier = "geth" // Client identifier to be used by the database
 )
 
 var (

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	clientIdentifier = "phoenix" // Client identifier to advertise over the network
+	clientIdentifier = "core" // Client identifier to advertise over the network
 )
 
 var (
@@ -56,7 +56,7 @@ var (
 	gitCommit = ""
 	gitDate   = ""
 	// The app that holds all commands and flags.
-	app = utils.NewApp(gitCommit, gitDate, "the phoenix go-ethereum command line interface")
+	app = utils.NewApp(gitCommit, gitDate, "the ETC Core Go-Ethereum command line interface")
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
 		utils.IdentityFlag,
@@ -201,7 +201,7 @@ func init() {
 	// Initialize the CLI app and start Geth
 	app.Action = geth
 	app.HideVersion = true // we have a command to print the version
-	app.Copyright = "Copyright 2013-2020 The Phoenix and Go-Ethereum Authors"
+	app.Copyright = "Copyright 2013-2020 The ETC Core and Go-Ethereum Authors"
 	app.Commands = []cli.Command{
 		// See chaincmd.go:
 		initCommand,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	clientIdentifier = "geth" // Client identifier to advertise over the network
+	clientIdentifier = "phoenix" // Client identifier to advertise over the network
 )
 
 var (
@@ -56,7 +56,7 @@ var (
 	gitCommit = ""
 	gitDate   = ""
 	// The app that holds all commands and flags.
-	app = utils.NewApp(gitCommit, gitDate, "the go-ethereum command line interface")
+	app = utils.NewApp(gitCommit, gitDate, "the phoenix go-ethereum command line interface")
 	// flags that configure the node
 	nodeFlags = []cli.Flag{
 		utils.IdentityFlag,
@@ -201,7 +201,7 @@ func init() {
 	// Initialize the CLI app and start Geth
 	app.Action = geth
 	app.HideVersion = true // we have a command to print the version
-	app.Copyright = "Copyright 2013-2019 The go-ethereum Authors"
+	app.Copyright = "Copyright 2013-2020 The Phoenix and Go-Ethereum Authors"
 	app.Commands = []cli.Command{
 		// See chaincmd.go:
 		initCommand,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	clientIdentifier = "core" // Client identifier to advertise over the network
+	clientIdentifier   = "core" // Client identifier to advertise over the network
 	databaseIdentifier = "geth" // Client identifier to be used by the database
 )
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -31,7 +31,7 @@ import (
 var AppHelpTemplate = `NAME:
    {{.App.Name}} - {{.App.Usage}}
 
-   Copyright 2013-2019 The go-ethereum Authors
+   {{.App.Copyright}}
 
 USAGE:
    {{.App.HelpName}} [options]{{if .App.Commands}} command [command options]{{end}} {{if .App.ArgsUsage}}{{.App.ArgsUsage}}{{else}}[arguments...]{{end}}

--- a/node/config.go
+++ b/node/config.go
@@ -287,9 +287,9 @@ func (c *Config) ExtRPCEnabled() bool {
 // NodeName returns the devp2p node identifier.
 func (c *Config) NodeName() string {
 	name := c.name()
-	// Backwards compatibility: previous versions used title-cased "Geth", keep that.
-	if name == "geth" || name == "geth-testnet" {
-		name = "Geth"
+	// Backwards compatibility: previous versions used Geth or MultiGeth
+	if name == "geth" || name == "geth-testnet" || name == "multigeth" || name == "MultiGeth" {
+		name = "PhoenixGeth"
 	}
 	if params.VersionName != "" {
 		name = params.VersionName

--- a/node/config.go
+++ b/node/config.go
@@ -289,7 +289,7 @@ func (c *Config) NodeName() string {
 	name := c.name()
 	// Backwards compatibility: previous versions used Geth or MultiGeth
 	if strings.ToLower(name) == "geth" || strings.ToLower(name) == "geth-testnet" || strings.ToLower(name) == "multigeth" {
-		name = "PhoenixGeth"
+		name = "CoreGeth"
 	}
 	if params.VersionName != "" {
 		name = params.VersionName

--- a/node/config.go
+++ b/node/config.go
@@ -288,7 +288,7 @@ func (c *Config) ExtRPCEnabled() bool {
 func (c *Config) NodeName() string {
 	name := c.name()
 	// Backwards compatibility: previous versions used Geth or MultiGeth
-	if name == "geth" || name == "geth-testnet" || name == "multigeth" || name == "MultiGeth" {
+	if strings.ToLower(name) == "geth" || strings.ToLower(name) == "geth-testnet" || strings.ToLower(name) == "multigeth" {
 		name = "PhoenixGeth"
 	}
 	if params.VersionName != "" {

--- a/params/version.go
+++ b/params/version.go
@@ -25,7 +25,7 @@ const (
 	VersionMinor = 9          // Minor version component of the current release
 	VersionPatch = 10         // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
-	VersionName  = "PhoenixGeth"
+	VersionName  = "CoreGeth"
 )
 
 // Version holds the textual version string.

--- a/params/version.go
+++ b/params/version.go
@@ -25,7 +25,7 @@ const (
 	VersionMinor = 9          // Minor version component of the current release
 	VersionPatch = 10         // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
-	VersionName  = "MultiGeth"
+	VersionName  = "PhoenixGeth"
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
ref #146 

---

because people asked why we need to rename:

1. we don't have access to the Multi-Geth repository and brand
2. we cannot have our own competing release track under the same name
3. with Multi-Geth barely being maintained, we need to make our repository stand out as independent project
4. changing client identifiers helps with analyzing the health of the network