### PR TITLE
core/[state|vm],trie: inspect and test getbalance costs for DNE addrs

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -62,6 +62,7 @@ type Trie interface {
 	// TryGet returns the value for key stored in the trie. The value bytes must
 	// not be modified by the caller. If a node was not found in the database, a
 	// trie.MissingNodeError is returned.
+	// $$$ balbad beep
 	TryGet(key []byte) ([]byte, error)
 
 	// TryUpdate associates key with value in the trie. If value has length zero, any

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -224,6 +224,7 @@ func (s *StateDB) Empty(addr common.Address) bool {
 
 // Retrieve the balance from the given address or 0 if object not found
 func (s *StateDB) GetBalance(addr common.Address) *big.Int {
+	// balbad beep $$$
 	stateObject := s.getStateObject(addr)
 	if stateObject != nil {
 		return stateObject.Balance()
@@ -454,9 +455,12 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 // the object is not found or was deleted in this execution context. If you need
 // to differentiate between non-existent/just-deleted, use getDeletedStateObject.
 func (s *StateDB) getStateObject(addr common.Address) *stateObject {
+	//fmt.Println("Getting state object...")
+	//balbad beep $$$
 	if obj := s.getDeletedStateObject(addr); obj != nil && !obj.deleted {
 		return obj
 	}
+	//fmt.Println("Done getting state object.")
 	return nil
 }
 
@@ -474,6 +478,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
 	}
 	// Load the object from the database
+	// balbad beep $$$
 	enc, err := s.trie.TryGet(addr[:])
 	if len(enc) == 0 {
 		s.setError(err)

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -680,3 +680,39 @@ func TestDeleteCreateRevert(t *testing.T) {
 		t.Fatalf("self-destructed contract came alive")
 	}
 }
+
+func BenchmarkStateDB_GetBalance_Existing(bench *testing.B) {
+	state, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+
+	accs := []string{"fah", "so", "lah", "tee", "doh"}
+	for _, a := range accs {
+		addr := toAddr([]byte(a))
+		state.SetBalance(addr, big.NewInt(1))
+	}
+	root, _ := state.Commit(false)
+	state.Reset(root)
+
+	for i := 0; i < bench.N; i++ {
+		for _, a := range accs {
+			state.GetBalance(toAddr([]byte(a)))
+		}
+	}
+}
+
+func BenchmarkStateDB_GetBalance_DNE(bench *testing.B) {
+	state, _ := New(common.Hash{}, NewDatabase(rawdb.NewMemoryDatabase()))
+
+	accs := []string{"fah", "so", "lah", "tee", "doh"}
+	//for _, a := range accs {
+	//	addr := toAddr([]byte(a))
+	//	state.SetBalance(addr, big.NewInt(1))
+	//}
+	root, _ := state.Commit(false)
+	state.Reset(root)
+
+	for i := 0; i < bench.N; i++ {
+		for _, a := range accs {
+			state.GetBalance(toAddr([]byte(a)))
+		}
+	}
+}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -411,6 +411,7 @@ func opAddress(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memo
 
 func opBalance(pc *uint64, interpreter *EVMInterpreter, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	slot := stack.peek()
+	// balbad beep $$$
 	slot.Set(interpreter.evm.StateDB.GetBalance(common.BigToAddress(slot)))
 	return nil, nil
 }

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -111,6 +111,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 	// set the receiver's (the executing contract) code for execution.
 	cfg.State.SetCode(address, code)
 	// Call the code with the given configuration.
+	//log.Println("Calling...")
 	ret, _, err := vmenv.Call(
 		sender,
 		common.BytesToAddress([]byte("contract")),

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -75,6 +75,7 @@ func (t *SecureTrie) Get(key []byte) []byte {
 // TryGet returns the value for key stored in the trie.
 // The value bytes must not be modified by the caller.
 // If a node was not found in the database, a MissingNodeError is returned.
+// $$$ beep
 func (t *SecureTrie) TryGet(key []byte) ([]byte, error) {
 	return t.trie.TryGet(t.hashKey(key))
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -105,6 +105,7 @@ func (t *Trie) TryGet(key []byte) ([]byte, error) {
 	return value, err
 }
 
+// tryGet can take a long time for nonexistent keys.
 func (t *Trie) tryGet(origNode node, key []byte, pos int) (value []byte, newnode node, didResolve bool, err error) {
 	switch n := (origNode).(type) {
 	case nil:


### PR DESCRIPTION
Benchmarks for DNE (Do Not Exist) address `BALANCE` calls.

```
> go test -bench Benchmark.*GetBalance ./core/state/...
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/state
BenchmarkStateDB_GetBalance_Existing-12          2528650
490 ns/op
BenchmarkStateDB_GetBalance_DNE-12                252471
4267 ns/op
PASS
ok      github.com/ethereum/go-ethereum/core/state      10.503s

> go test -bench Benchmark.*BalanceDNE ./core/vm/...
PASS
ok      github.com/ethereum/go-ethereum/core/vm 0.155s
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm/runtime
BenchmarkEVM_BalanceDNE_Gas40-12                   42105
28429 ns/op
BenchmarkEVM_BalanceDNE_Gas400-12                  43124
28241 ns/op
BenchmarkEVM_BalanceDNE_Gas4000-12                 30919
39121 ns/op
BenchmarkEVM_BalanceDNE_Gas40000-12                 9037
155781 ns/op
BenchmarkEVM_BalanceDNE_Gas004Gwei-12                 10
127698023 ns/op
BenchmarkEVM_BalanceDNE_Gas04Gwei-12                   1
1098864244 ns/op
BenchmarkEVM_BalanceDNE_Gas4Gwei-12                    1
11883739376 ns/op
BenchmarkEVM_BalanceDNE_Gas40Gwei-12                   1
119108679718 ns/op
PASS
ok      github.com/ethereum/go-ethereum/core/vm/runtime 139.523s
```

Signed-off-by: meows <b5c6@protonmail.com>